### PR TITLE
feat: support nested .copytreeignore files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Added support for `.copytreeignore` files in subdirectories.
+
 ## [0.11.0] - 2025-08-05
 
 ### Major Changes

--- a/src/utils/fileFilter.js
+++ b/src/utils/fileFilter.js
@@ -138,8 +138,8 @@ class FileFilter {
   
   createChildFilter(subPath) {
     const childFilter = new FileFilter(path.join(this.basePath, subPath));
-    // Copy current patterns
-    childFilter.patterns = [...this.patterns];
+    // Combine parent patterns with child patterns so subdirectory rules take precedence
+    childFilter.patterns = [...this.patterns, ...childFilter.patterns];
     return childFilter;
   }
 }

--- a/tests/integration/pipeline.test.js
+++ b/tests/integration/pipeline.test.js
@@ -97,6 +97,31 @@ describe('Pipeline Integration Tests', () => {
       ]);
     });
 
+    it('should respect .copytreeignore in subdirectories', async () => {
+      // Create nested directory with its own .copytreeignore
+      await fs.ensureDir(path.join(tempDir, 'src/internal'));
+      await fs.writeFile(path.join(tempDir, 'src/internal/secret.js'), 'top secret');
+      await fs.writeFile(path.join(tempDir, 'src/.copytreeignore'), 'internal/');
+
+      pipeline.through([
+        new FileDiscoveryStage({
+          basePath: tempDir,
+          patterns: ['**/*.js'],
+          respectGitignore: true,
+        }),
+      ]);
+
+      const result = await pipeline.process({
+        basePath: tempDir,
+        profile: {},
+        options: {},
+      });
+
+      const paths = result.files.map((f) => f.path);
+      expect(paths).toContain('src/app.js');
+      expect(paths).not.toContain('src/internal/secret.js');
+    });
+
     it('should load file contents', async () => {
       pipeline
         .through([


### PR DESCRIPTION
## Summary
- handle `.copytreeignore` files within subdirectories during file discovery
- ensure child FileFilters retain parent ignore patterns
- test ignoring via `.copytreeignore` in nested folders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a027fe7f88832aa4e4dffdde29b373