### PR TITLE
docs: correct default output format to xml in documentation

### DIFF
--- a/docs/cli/copytree-reference.md
+++ b/docs/cli/copytree-reference.md
@@ -96,13 +96,13 @@ copytree --no-clipboard --display
 #### `--format=<type>`
 Output format: `markdown|md`, `xml`, `json`, or `tree`.
 
-**Default:** `markdown`
+**Default:** `xml`
 
 ```bash
 copytree --format json
 copytree --format tree
-copytree --format markdown  # default
-copytree --format xml
+copytree --format xml  # default
+copytree --format markdown
 ```
 
 ### Display Control Options

--- a/docs/usage/basic-usage.md
+++ b/docs/usage/basic-usage.md
@@ -118,12 +118,12 @@ copytree --clipboard
 ### 2. File Output
 
 ```bash
-# Save to specific file (default markdown)
-copytree --output project-snapshot.md
+# Save to specific file (defaults to xml)
+copytree --output project-snapshot.xml
 
 # Different formats
 copytree --output snapshot.json --format json
-copytree --output snapshot.xml --format xml
+copytree --output snapshot.md --format markdown
 ```
 
 ### 3. Console Display


### PR DESCRIPTION
- Update CLI reference to specify xml as default format
- Change example comments to reflect xml as default instead of markdown
- Fix basic usage guide file output examples to show xml default
- Reorder format examples to demonstrate non-default options