### PR TITLE
Fix intermittent test failures from filesystem race conditions

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 export default {
   testEnvironment: 'node',
-  
+
   // Test file patterns
   testMatch: [
     '**/tests/**/*.test.js',
@@ -8,7 +8,7 @@ export default {
     '**/tests/**/*.test.jsx',
     '**/tests/**/*.spec.jsx'
   ],
-  
+
   // Coverage configuration
   collectCoverage: false, // Set to true when running coverage
   collectCoverageFrom: [
@@ -22,7 +22,15 @@ export default {
   ],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'html'],
-  
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
+
   // Module paths - keep mocks for ESM
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1.js',
@@ -34,13 +42,13 @@ export default {
     '^ink-testing-library$': '<rootDir>/tests/mocks/ink-testing-library.js',
     '^ink$': '<rootDir>/tests/mocks/ink.js'
   },
-  
+
   // Module directories
   moduleDirectories: ['node_modules', 'src'],
-  
+
   // Setup files
   setupFiles: ['<rootDir>/tests/setup-mocks.js'],
-  setupFilesAfterEnv: ['<rootDir>/tests/setup.js'],
+  setupFilesAfterEnv: ['<rootDir>/tests/setup.js', '<rootDir>/tests/jest.setup.js'],
   
   // Transform files for ESM
   transform: {

--- a/tests/helpers/tempfs.js
+++ b/tests/helpers/tempfs.js
@@ -1,0 +1,138 @@
+/**
+ * Temporary filesystem management for tests
+ *
+ * Provides deterministic, race-free temporary directory management
+ * with robust cleanup that handles macOS/APFS peculiarities.
+ */
+
+import fs from 'fs';
+import fsp from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { randomUUID } from 'crypto';
+
+/**
+ * Sanitize a label for use in filesystem paths
+ */
+function sanitize(name = '') {
+  return String(name)
+    .replace(/[^a-z0-9._-]+/gi, '-')
+    .slice(0, 80);
+}
+
+/**
+ * Write .metadata_never_index to disable Spotlight indexing (macOS)
+ */
+async function ensureNoIndex(dir) {
+  try {
+    await fsp.writeFile(path.join(dir, '.metadata_never_index'), '');
+  } catch {
+    // Ignore errors - this is best-effort optimization for macOS
+  }
+}
+
+/**
+ * Settle filesystem operations
+ *
+ * Yields to allow:
+ * - Pending microtasks to complete
+ * - File handles to close
+ * - OS filesystem cache to flush
+ * - APFS/Spotlight to finish background operations
+ *
+ * @param {number} ms - Milliseconds to wait (default: 50)
+ */
+export async function settleFs(ms = 50) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+  await Promise.resolve(); // Drain microtasks
+}
+
+/**
+ * Safely remove a directory with retries and backoff
+ *
+ * Handles APFS transient states and Spotlight indexing races
+ * with exponential backoff on ENOTEMPTY/EBUSY errors.
+ *
+ * @param {string} target - Directory to remove
+ * @param {object} options - Removal options
+ * @param {number} options.maxRetries - Maximum retry attempts (default: 5)
+ * @param {number} options.retryDelay - Initial retry delay in ms (default: 100)
+ */
+export async function safeRemove(target, { maxRetries = 5, retryDelay = 100 } = {}) {
+  const opts = { recursive: true, force: true, maxRetries, retryDelay };
+
+  try {
+    await fsp.rm(target, opts);
+    return;
+  } catch (e) {
+    // If not ENOTEMPTY/EBUSY or doesn't exist, rethrow
+    if (e?.code === 'ENOENT') return; // Already removed
+    if (e?.code !== 'ENOTEMPTY' && e?.code !== 'EBUSY') throw e;
+  }
+
+  // Extra bounded backoff for APFS/Spotlight transient states
+  let delay = retryDelay;
+  for (let i = 0; i < maxRetries; i++) {
+    await settleFs(delay);
+    try {
+      await fsp.rm(target, opts);
+      return;
+    } catch (e) {
+      if (e?.code === 'ENOENT') return; // Removed by another process
+      if (e?.code !== 'ENOTEMPTY' && e?.code !== 'EBUSY') throw e;
+      delay = Math.min(delay * 2, 500); // Exponential backoff, capped at 500ms
+    }
+  }
+
+  // Final attempt - let error surface to fail test meaningfully
+  await fsp.rm(target, opts);
+}
+
+/**
+ * Create a test-scoped temporary directory
+ *
+ * Returns an object with:
+ * - path: Absolute path to the temp directory
+ * - cleanup: Async function to remove the directory
+ *
+ * Directory structure:
+ * <os.tmpdir()>/copytree-tests/<PID>-<WORKER_ID>-<timestamp>-<uuid>/<label>/
+ *
+ * @param {string} label - Optional label for the directory
+ * @returns {Promise<{path: string, cleanup: () => Promise<void>}>}
+ */
+export async function createTestTempDir(label = '') {
+  const base = path.join(os.tmpdir(), 'copytree-tests');
+  const unique = `${process.pid}-${process.env.JEST_WORKER_ID || '0'}-${Date.now()}-${randomUUID()}`;
+  const dir = path.join(base, unique, sanitize(label));
+
+  await fsp.mkdir(dir, { recursive: true });
+  await ensureNoIndex(path.join(base, unique));
+
+  return {
+    path: dir,
+    cleanup: async () => {
+      await settleFs(50);
+      await safeRemove(path.join(base, unique));
+    },
+  };
+}
+
+/**
+ * Execute a function with a temporary directory
+ *
+ * Creates a temp directory, executes the function, and always
+ * cleans up afterwards (even if the function throws).
+ *
+ * @param {string} label - Label for the temp directory
+ * @param {(dir: string) => Promise<T>} fn - Async function to execute
+ * @returns {Promise<T>} Result of the function
+ */
+export async function withTempDir(label, fn) {
+  const { path: dir, cleanup } = await createTestTempDir(label);
+  try {
+    return await fn(dir);
+  } finally {
+    await cleanup();
+  }
+}

--- a/tests/integration/commands.test.js
+++ b/tests/integration/commands.test.js
@@ -5,8 +5,9 @@ import { exec } from 'child_process';
 import path from 'path';
 import fs from 'fs-extra';
 import { readFileSync, existsSync, readdirSync } from 'fs';
-import os from 'os';
 import { promises as fsPromises } from 'fs';
+import { withTempDir, settleFs } from '../helpers/tempfs.js';
+
 // Jest/Babel compatibility: construct the test directory path
 const __dirname = path.join(process.cwd(), 'tests/integration');
 
@@ -48,52 +49,49 @@ function runCommand(command, options = {}) {
 }
 
 describe('Command Integration Tests', () => {
-  let tempDir;
-  let testProjectDir;
   const cliPath = path.join(__dirname, '../../bin/copytree.js');
 
-  beforeEach(async () => {
-    try {
-      tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'copytree-integration-'));
-      testProjectDir = path.join(tempDir, 'test-project');
+  // Helper to create a test project structure
+  async function createTestProject(tempDir) {
+    const testProjectDir = path.join(tempDir, 'test-project');
 
-      // Create test project structure using native fs.promises
-      await fsPromises.mkdir(testProjectDir, { recursive: true });
+    // Create test project structure using native fs.promises
+    await fsPromises.mkdir(testProjectDir, { recursive: true });
 
-      // Double-check directory exists
-      const stats = await fsPromises.stat(testProjectDir);
-      if (!stats.isDirectory()) {
-        throw new Error(`Directory not created: ${testProjectDir}`);
-      }
+    // Double-check directory exists
+    const stats = await fsPromises.stat(testProjectDir);
+    if (!stats.isDirectory()) {
+      throw new Error(`Directory not created: ${testProjectDir}`);
+    }
 
-      await fs.writeFile(
-        path.join(testProjectDir, 'README.md'),
-        '# Test Project\n\nThis is a test project.',
-      );
-      await fs.writeFile(
-        path.join(testProjectDir, 'package.json'),
-        JSON.stringify(
-          {
-            name: 'test-project',
-            version: '1.0.0',
-            description: 'Test project for copytree',
-          },
-          null,
-          2,
-        ),
-      );
+    await fs.writeFile(
+      path.join(testProjectDir, 'README.md'),
+      '# Test Project\n\nThis is a test project.',
+    );
+    await fs.writeFile(
+      path.join(testProjectDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: 'test-project',
+          version: '1.0.0',
+          description: 'Test project for copytree',
+        },
+        null,
+        2,
+      ),
+    );
 
-      await fsPromises.mkdir(path.join(testProjectDir, 'src'), { recursive: true });
-      await fs.writeFile(path.join(testProjectDir, 'src/index.js'), 'console.log("Hello World");');
-      await fs.writeFile(
-        path.join(testProjectDir, 'src/utils.js'),
-        'module.exports = { helper: () => {} };',
-      );
-      await fs.writeFile(path.join(testProjectDir, 'test.txt'), 'This is a test file.');
+    await fsPromises.mkdir(path.join(testProjectDir, 'src'), { recursive: true });
+    await fs.writeFile(path.join(testProjectDir, 'src/index.js'), 'console.log("Hello World");');
+    await fs.writeFile(
+      path.join(testProjectDir, 'src/utils.js'),
+      'module.exports = { helper: () => {} };',
+    );
+    await fs.writeFile(path.join(testProjectDir, 'test.txt'), 'This is a test file.');
 
-      // Create test profile for integration tests
-      await fsPromises.mkdir(path.join(testProjectDir, '.copytree'), { recursive: true });
-      const testProfile = `name: test-profile
+    // Create test profile for integration tests
+    await fsPromises.mkdir(path.join(testProjectDir, '.copytree'), { recursive: true });
+    const testProfile = `name: test-profile
 description: Test profile for integration tests
 version: 1.0.0
 
@@ -124,20 +122,10 @@ output:
   includeMetadata: true
   addLineNumbers: false
   prettyPrint: true`;
-      await fs.writeFile(path.join(testProjectDir, '.copytree/test-profile.yml'), testProfile);
-    } catch (error) {
-      console.error('Error in beforeEach:', error);
-      console.error('TempDir:', tempDir);
-      console.error('TestProjectDir:', testProjectDir);
-      throw error;
-    }
-  });
+    await fs.writeFile(path.join(testProjectDir, '.copytree/test-profile.yml'), testProfile);
 
-  afterEach(async () => {
-    if (tempDir && (await fs.pathExists(tempDir))) {
-      await fs.remove(tempDir);
-    }
-  });
+    return testProjectDir;
+  }
 
   describe('Help and Version', () => {
     test('should show help message', async () => {
@@ -158,63 +146,70 @@ output:
 
   describe('Copy Command', () => {
     test('should copy files to XML output', async () => {
-      const outputFile = 'output.xml';
-      console.log('Test project dir:', testProjectDir);
-      console.log('CLI path:', cliPath);
+      await withTempDir('copy-xml-output', async (tempDir) => {
+        const testProjectDir = await createTestProject(tempDir);
+        const outputFile = 'output.xml';
+        console.log('Test project dir:', testProjectDir);
+        console.log('CLI path:', cliPath);
 
-      const { exitCode, stderr, stdout } = await runCommand(
-        `node "${cliPath}" copy . --output "${outputFile}" --format xml --always "**/*.txt" "**/*.md" "**/*.json"`,
-        { cwd: testProjectDir, timeout: 45000 },
-      );
+        const { exitCode, stderr, stdout } = await runCommand(
+          `node "${cliPath}" copy . --output "${outputFile}" --format xml --always "**/*.txt" "**/*.md" "**/*.json"`,
+          { cwd: testProjectDir, timeout: 45000 },
+        );
 
-      console.log('Command output:', { exitCode, stdout, stderr });
+        console.log('Command output:', { exitCode, stdout, stderr });
 
-      if (exitCode !== 0) {
-        console.error('Copy command failed:');
-        console.error('Exit code:', exitCode);
-        console.error('Stderr:', stderr);
-        console.error('Stdout:', stdout);
-      }
-
-      expect(exitCode).toBe(0);
-
-      // Check output file exists and contains XML
-      const fullOutputPath = path.join(testProjectDir, outputFile);
-      // Add a small delay to ensure file writing is complete
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      // Use native fs for file existence check
-      const fileExists = existsSync(fullOutputPath);
-      console.log('File exists check:', { fullOutputPath, fileExists });
-      if (!fileExists) {
-        console.error('Output file not created at:', fullOutputPath);
-        const dirContents = readdirSync(testProjectDir);
-        console.error('Test project dir contents:', dirContents);
-        console.error('Stdout was:', stdout);
-        console.error('Stderr was:', stderr);
-
-        // Check if output.xml exists elsewhere
-        if (dirContents.includes('output.xml')) {
-          console.error('output.xml IS in the directory!');
+        if (exitCode !== 0) {
+          console.error('Copy command failed:');
+          console.error('Exit code:', exitCode);
+          console.error('Stderr:', stderr);
+          console.error('Stdout:', stdout);
         }
-      }
-      expect(fileExists).toBe(true);
 
-      const content = readFileSync(fullOutputPath, 'utf8');
-      expect(content).toContain('<?xml');
-      expect(content).toMatch(/<ct:files[\s\/>]/); // Match <ct:files> or <ct:files/>
+        expect(exitCode).toBe(0);
+
+        // Check output file exists and contains XML
+        const fullOutputPath = path.join(testProjectDir, outputFile);
+        await settleFs(100);
+
+        // Use native fs for file existence check
+        const fileExists = existsSync(fullOutputPath);
+        console.log('File exists check:', { fullOutputPath, fileExists });
+        if (!fileExists) {
+          console.error('Output file not created at:', fullOutputPath);
+          const dirContents = readdirSync(testProjectDir);
+          console.error('Test project dir contents:', dirContents);
+          console.error('Stdout was:', stdout);
+          console.error('Stderr was:', stderr);
+
+          // Check if output.xml exists elsewhere
+          if (dirContents.includes('output.xml')) {
+            console.error('output.xml IS in the directory!');
+          }
+        }
+        expect(fileExists).toBe(true);
+
+        const content = readFileSync(fullOutputPath, 'utf8');
+        expect(content).toContain('<?xml');
+        expect(content).toMatch(/<ct:files[\s\/>]/); // Match <ct:files> or <ct:files/>
+      });
     });
 
     test('should copy with dry-run flag', async () => {
-      // Use current working directory instead of temp directory for now
-      const { stdout, stderr, exitCode } = await runCommand(`node "${cliPath}" copy . --dry-run`, {
-        cwd: testProjectDir,
-      });
+      await withTempDir('copy-dry-run', async (tempDir) => {
+        const testProjectDir = await createTestProject(tempDir);
+        const { stdout, stderr, exitCode } = await runCommand(
+          `node "${cliPath}" copy . --dry-run`,
+          {
+            cwd: testProjectDir,
+          },
+        );
 
-      expect(exitCode).toBe(0);
-      // Check both stdout and stderr as output might go to stderr
-      const output = stdout + stderr;
-      expect(output).toMatch(/dry run/i);
+        expect(exitCode).toBe(0);
+        // Check both stdout and stderr as output might go to stderr
+        const output = stdout + stderr;
+        expect(output).toMatch(/dry run/i);
+      });
     });
 
     test('should handle non-existent directory', async () => {
@@ -294,115 +289,137 @@ output:
 
   describe('Output Formats', () => {
     test('should support JSON output format', async () => {
-      const outputFile = 'output.json';
-      const { exitCode, stderr, stdout } = await runCommand(
-        `node "${cliPath}" copy . --output "${outputFile}" --format json --always "**/*.txt" "**/*.md" "**/*.json"`,
-        { cwd: testProjectDir },
-      );
+      await withTempDir('json-output-format', async (tempDir) => {
+        const testProjectDir = await createTestProject(tempDir);
+        const outputFile = 'output.json';
+        const { exitCode, stderr, stdout } = await runCommand(
+          `node "${cliPath}" copy . --output "${outputFile}" --format json --always "**/*.txt" "**/*.md" "**/*.json"`,
+          { cwd: testProjectDir },
+        );
 
-      if (exitCode !== 0) {
-        console.error('JSON output test failed:');
-        console.error('Exit code:', exitCode);
-        console.error('Stderr:', stderr);
-        console.error('Stdout:', stdout);
-      }
+        if (exitCode !== 0) {
+          console.error('JSON output test failed:');
+          console.error('Exit code:', exitCode);
+          console.error('Stderr:', stderr);
+          console.error('Stdout:', stdout);
+        }
 
-      expect(exitCode).toBe(0);
+        expect(exitCode).toBe(0);
 
-      const fullOutputPath = path.join(testProjectDir, outputFile);
-      const fileExists = existsSync(fullOutputPath);
-      if (!fileExists) {
-        console.error('JSON output file not created at:', fullOutputPath);
-      }
-      expect(fileExists).toBe(true);
+        const fullOutputPath = path.join(testProjectDir, outputFile);
+        await settleFs(100);
+        const fileExists = existsSync(fullOutputPath);
+        if (!fileExists) {
+          console.error('JSON output file not created at:', fullOutputPath);
+        }
+        expect(fileExists).toBe(true);
 
-      const content = readFileSync(fullOutputPath, 'utf8');
-      expect(() => JSON.parse(content)).not.toThrow();
+        const content = readFileSync(fullOutputPath, 'utf8');
+        expect(() => JSON.parse(content)).not.toThrow();
+      });
     });
 
     test('should support tree output format', async () => {
-      const { stdout, stderr, exitCode } = await runCommand(
-        `node "${cliPath}" copy . --format tree --display`,
-        { cwd: testProjectDir },
-      );
+      await withTempDir('tree-output-format', async (tempDir) => {
+        const testProjectDir = await createTestProject(tempDir);
+        const { stdout, stderr, exitCode } = await runCommand(
+          `node "${cliPath}" copy . --format tree --display`,
+          { cwd: testProjectDir },
+        );
 
-      if (exitCode !== 0) {
-        console.error('Tree format test failed:');
-        console.error('Exit code:', exitCode);
-        console.error('Stderr:', stderr);
-        console.error('Stdout:', stdout);
-      }
+        if (exitCode !== 0) {
+          console.error('Tree format test failed:');
+          console.error('Exit code:', exitCode);
+          console.error('Stderr:', stderr);
+          console.error('Stdout:', stdout);
+        }
 
-      expect(exitCode).toBe(0);
-      // Check for tree-like output (might be different symbols or file names)
-      const output = stdout + stderr;
-      expect(output).toMatch(/index\.js|README\.md|package\.json|src|test-project/);
+        expect(exitCode).toBe(0);
+        // Check for tree-like output (might be different symbols or file names)
+        const output = stdout + stderr;
+        expect(output).toMatch(/index\.js|README\.md|package\.json|src|test-project/);
+      });
     });
   });
 
   describe('File Filtering', () => {
     test('should respect filter patterns', async () => {
-      // First verify files exist
-      const srcPath = path.join(testProjectDir, 'src');
-      const indexPath = path.join(srcPath, 'index.js');
-      console.log('Checking files before test:');
-      console.log('src exists:', existsSync(srcPath));
-      console.log('index.js exists:', existsSync(indexPath));
-      if (existsSync(srcPath)) {
-        console.log('src contents:', readdirSync(srcPath));
-      }
+      await withTempDir('filter-patterns', async (tempDir) => {
+        const testProjectDir = await createTestProject(tempDir);
+        // First verify files exist
+        const srcPath = path.join(testProjectDir, 'src');
+        const indexPath = path.join(srcPath, 'index.js');
+        console.log('Checking files before test:');
+        console.log('src exists:', existsSync(srcPath));
+        console.log('index.js exists:', existsSync(indexPath));
+        if (existsSync(srcPath)) {
+          console.log('src contents:', readdirSync(srcPath));
+        }
 
-      const { stdout, stderr, exitCode } = await runCommand(
-        `node "${cliPath}" copy . --filter "**/*.js" --always "**/*.js" --format tree --display`,
-        { cwd: testProjectDir },
-      );
+        const { stdout, stderr, exitCode } = await runCommand(
+          `node "${cliPath}" copy . --filter "**/*.js" --always "**/*.js" --format tree --display`,
+          { cwd: testProjectDir },
+        );
 
-      console.log('Filter test output:', { exitCode, stdout: stdout.substring(0, 500), stderr });
+        console.log('Filter test output:', { exitCode, stdout: stdout.substring(0, 500), stderr });
 
-      expect(exitCode).toBe(0);
-      // Filter adds to existing patterns, so all files might still be shown
-      // Just verify that JS files are included in the output
-      expect(stdout).toContain('index.js');
-      expect(stdout).toContain('utils.js');
+        expect(exitCode).toBe(0);
+        // Filter adds to existing patterns, so all files might still be shown
+        // Just verify that JS files are included in the output
+        expect(stdout).toContain('index.js');
+        expect(stdout).toContain('utils.js');
+      });
     });
 
     test('should respect filter patterns for including specific files', async () => {
-      // Test that --filter and --always options work correctly to include specific file types
-      const { stdout, exitCode } = await runCommand(
-        `node "${cliPath}" copy . --filter "**/*.js" "**/*.md" --always "**/*.js" "**/*.md" --format tree --display`,
-        { cwd: testProjectDir },
-      );
+      await withTempDir('filter-specific-files', async (tempDir) => {
+        const testProjectDir = await createTestProject(tempDir);
+        // Test that --filter and --always options work correctly to include specific file types
+        const { stdout, exitCode } = await runCommand(
+          `node "${cliPath}" copy . --filter "**/*.js" "**/*.md" --always "**/*.js" "**/*.md" --format tree --display`,
+          { cwd: testProjectDir },
+        );
 
-      expect(exitCode).toBe(0);
-      // Verify that the specified file types are included
-      expect(stdout).toContain('index.js');
-      expect(stdout).toContain('README.md');
+        expect(exitCode).toBe(0);
+        // Verify that the specified file types are included
+        expect(stdout).toContain('index.js');
+        expect(stdout).toContain('README.md');
+      });
     });
   });
 
   describe('Clipboard Integration', () => {
     test('should copy to clipboard when no output specified', async () => {
-      const { stdout, stderr, exitCode } = await runCommand(`node "${cliPath}" copy . --dry-run`, {
-        cwd: testProjectDir,
-      });
+      await withTempDir('clipboard-integration', async (tempDir) => {
+        const testProjectDir = await createTestProject(tempDir);
+        const { stdout, stderr, exitCode } = await runCommand(
+          `node "${cliPath}" copy . --dry-run`,
+          {
+            cwd: testProjectDir,
+          },
+        );
 
-      expect(exitCode).toBe(0);
-      const output = stdout + stderr;
-      expect(output).toMatch(/dry run/i);
-      // Note: We can't easily test actual clipboard in CI, so we test dry-run
+        expect(exitCode).toBe(0);
+        const output = stdout + stderr;
+        expect(output).toMatch(/dry run/i);
+        // Note: We can't easily test actual clipboard in CI, so we test dry-run
+      });
     });
   });
 
   describe('Performance', () => {
     test('should complete copy command within reasonable time', async () => {
-      const startTime = Date.now();
-      const { exitCode } = await runCommand(`node "${cliPath}" copy . --dry-run`, {
-        cwd: testProjectDir,
-      });
-      const duration = Date.now() - startTime;
+      await withTempDir('performance-timing', async (tempDir) => {
+        const testProjectDir = await createTestProject(tempDir);
+        const startTime = Date.now();
+        const { exitCode } = await runCommand(`node "${cliPath}" copy . --dry-run`, {
+          cwd: testProjectDir,
+        });
+        const duration = Date.now() - startTime;
 
-      expect(exitCode).toBe(0);
-      expect(duration).toBeLessThan(10000); // Should complete within 10 seconds
+        expect(exitCode).toBe(0);
+        expect(duration).toBeLessThan(10000); // Should complete within 10 seconds
+      });
     });
   });
 });

--- a/tests/integration/forceInclude.test.js
+++ b/tests/integration/forceInclude.test.js
@@ -4,400 +4,479 @@ jest.unmock('fs-extra');
 // Static imports for Node.js modules
 import fs from 'fs-extra';
 import path from 'path';
-import os from 'os';
+import { withTempDir, settleFs } from '../helpers/tempfs.js';
 
 // Use dynamic imports for modules under test
-let Pipeline, FileDiscoveryStage, AlwaysIncludeStage, ProfileFilterStage, GitFilterStage;
+let Pipeline, FileDiscoveryStage, AlwaysIncludeStage, ProfileFilterStage;
 
 beforeAll(async () => {
   const pipelineModule = await import('../../src/pipeline/Pipeline.js');
   const fileDiscoveryStageModule = await import('../../src/pipeline/stages/FileDiscoveryStage.js');
   const alwaysIncludeStageModule = await import('../../src/pipeline/stages/AlwaysIncludeStage.js');
   const profileFilterStageModule = await import('../../src/pipeline/stages/ProfileFilterStage.js');
-  const gitFilterStageModule = await import('../../src/pipeline/stages/GitFilterStage.js');
 
   Pipeline = pipelineModule.default;
   FileDiscoveryStage = fileDiscoveryStageModule.default;
   AlwaysIncludeStage = alwaysIncludeStageModule.default;
   ProfileFilterStage = profileFilterStageModule.default;
-  GitFilterStage = gitFilterStageModule.default;
 });
 
+/**
+ * Create test directory structure with standard test files
+ * @param {string} tempDir - Path to the temporary directory
+ */
+async function createTestFiles(tempDir) {
+  // Create regular files
+  await fs.writeFile(path.join(tempDir, 'index.js'), 'console.log("Hello");');
+  await fs.writeFile(path.join(tempDir, 'utils.js'), 'export const util = () => {};');
+
+  // Create hidden directory with files
+  await fs.ensureDir(path.join(tempDir, '.example'));
+  await fs.writeFile(path.join(tempDir, '.example/secret.txt'), 'secret content');
+  await fs.writeFile(path.join(tempDir, '.example/config.json'), '{"key": "value"}');
+
+  // Create another hidden file at root
+  await fs.writeFile(path.join(tempDir, '.env'), 'API_KEY=test');
+}
+
 describe('Force Include Integration Tests', () => {
-  let tempDir;
-  let pipeline;
-
-  beforeEach(async () => {
-    // Create temporary test directory
-    tempDir = path.join(os.tmpdir(), `copytree-force-include-test-${Date.now()}`);
-    await fs.ensureDir(tempDir);
-
-    // Create regular files
-    await fs.writeFile(path.join(tempDir, 'index.js'), 'console.log("Hello");');
-    await fs.writeFile(path.join(tempDir, 'utils.js'), 'export const util = () => {};');
-
-    // Create hidden directory with files
-    await fs.ensureDir(path.join(tempDir, '.example'));
-    await fs.writeFile(path.join(tempDir, '.example/secret.txt'), 'secret content');
-    await fs.writeFile(path.join(tempDir, '.example/config.json'), '{"key": "value"}');
-
-    // Create another hidden file at root
-    await fs.writeFile(path.join(tempDir, '.env'), 'API_KEY=test');
-
-    pipeline = new Pipeline();
-  });
-
-  afterEach(async () => {
-    // Clean up temp directory
-    await fs.remove(tempDir);
-  });
-
   describe('.copytreeinclude file', () => {
     it('should discover hidden files listed in .copytreeinclude with explicit glob', async () => {
-      // Create .copytreeinclude file
-      await fs.writeFile(
-        path.join(tempDir, '.copytreeinclude'),
-        '.example/**\n.env\n# This is a comment\n',
-      );
+      await withTempDir('copytreeinclude-explicit-glob', async (tempDir) => {
+        await createTestFiles(tempDir);
 
-      pipeline.through([
-        new FileDiscoveryStage({
+        // Create .copytreeinclude file
+        await fs.writeFile(
+          path.join(tempDir, '.copytreeinclude'),
+          '.example/**\n.env\n# This is a comment\n',
+        );
+
+        const pipeline = new Pipeline();
+        pipeline.through([
+          new FileDiscoveryStage({
+            basePath: tempDir,
+            patterns: ['**/*'],
+            respectGitignore: false,
+            includeHidden: false, // Hidden files should still be discovered via forceInclude
+          }),
+        ]);
+
+        const result = await pipeline.process({
           basePath: tempDir,
-          patterns: ['**/*'],
-          respectGitignore: false,
-          includeHidden: false, // Hidden files should still be discovered via forceInclude
-        }),
-      ]);
+          profile: {},
+          options: {},
+        });
 
-      const result = await pipeline.process({
-        basePath: tempDir,
-        profile: {},
-        options: {},
+        await settleFs();
+
+        const paths = result.files.map((f) => f.path).sort();
+        expect(paths).toContain('.example/secret.txt');
+        expect(paths).toContain('.example/config.json');
+        expect(paths).toContain('.env');
       });
-
-      const paths = result.files.map((f) => f.path).sort();
-      expect(paths).toContain('.example/secret.txt');
-      expect(paths).toContain('.example/config.json');
-      expect(paths).toContain('.env');
     });
 
     it('should discover hidden directories with bare directory pattern', async () => {
-      // Create .copytreeinclude file with bare directory name (no explicit /**)
-      await fs.writeFile(path.join(tempDir, '.copytreeinclude'), '.example\n.env\n');
+      await withTempDir('copytreeinclude-bare-directory', async (tempDir) => {
+        await createTestFiles(tempDir);
 
-      pipeline.through([
-        new FileDiscoveryStage({
+        // Create .copytreeinclude file with bare directory name (no explicit /**)
+        await fs.writeFile(path.join(tempDir, '.copytreeinclude'), '.example\n.env\n');
+
+        const pipeline = new Pipeline();
+        pipeline.through([
+          new FileDiscoveryStage({
+            basePath: tempDir,
+            patterns: ['**/*'],
+            respectGitignore: false,
+            includeHidden: false,
+          }),
+        ]);
+
+        const result = await pipeline.process({
           basePath: tempDir,
-          patterns: ['**/*'],
-          respectGitignore: false,
-          includeHidden: false,
-        }),
-      ]);
+          profile: {},
+          options: {},
+        });
 
-      const result = await pipeline.process({
-        basePath: tempDir,
-        profile: {},
-        options: {},
+        await settleFs();
+
+        const paths = result.files.map((f) => f.path).sort();
+        expect(paths).toContain('.example/secret.txt');
+        expect(paths).toContain('.example/config.json');
+        expect(paths).toContain('.env');
       });
-
-      const paths = result.files.map((f) => f.path).sort();
-      expect(paths).toContain('.example/secret.txt');
-      expect(paths).toContain('.example/config.json');
-      expect(paths).toContain('.env');
     });
 
     it('should respect .copytreeinclude patterns even with .copytreeignore', async () => {
-      // Create .copytreeignore that excludes everything
-      await fs.writeFile(path.join(tempDir, '.copytreeignore'), '**/*\n');
+      await withTempDir('copytreeinclude-with-copytreeignore', async (tempDir) => {
+        await createTestFiles(tempDir);
 
-      // Create .copytreeinclude to force-include specific files
-      await fs.writeFile(path.join(tempDir, '.copytreeinclude'), '.example/**\n');
+        // Create .copytreeignore that excludes everything
+        await fs.writeFile(path.join(tempDir, '.copytreeignore'), '**/*\n');
 
-      pipeline.through([
-        new FileDiscoveryStage({
+        // Create .copytreeinclude to force-include specific files
+        await fs.writeFile(path.join(tempDir, '.copytreeinclude'), '.example/**\n');
+
+        const pipeline = new Pipeline();
+        pipeline.through([
+          new FileDiscoveryStage({
+            basePath: tempDir,
+            patterns: ['**/*'],
+            respectGitignore: true, // Should respect ignore files
+            includeHidden: false,
+          }),
+        ]);
+
+        const result = await pipeline.process({
           basePath: tempDir,
-          patterns: ['**/*'],
-          respectGitignore: true, // Should respect ignore files
-          includeHidden: false,
-        }),
-      ]);
+          profile: {},
+          options: {},
+        });
 
-      const result = await pipeline.process({
-        basePath: tempDir,
-        profile: {},
-        options: {},
+        await settleFs();
+
+        const paths = result.files.map((f) => f.path).sort();
+        expect(paths).toContain('.example/secret.txt');
+        expect(paths).toContain('.example/config.json');
       });
-
-      const paths = result.files.map((f) => f.path).sort();
-      expect(paths).toContain('.example/secret.txt');
-      expect(paths).toContain('.example/config.json');
     });
 
     it('should handle comments and empty lines in .copytreeinclude', async () => {
-      await fs.writeFile(
-        path.join(tempDir, '.copytreeinclude'),
-        '# This is a comment\n\n.example/**\n\n# Another comment\n.env\n',
-      );
+      await withTempDir('copytreeinclude-comments-empty-lines', async (tempDir) => {
+        await createTestFiles(tempDir);
 
-      pipeline.through([
-        new FileDiscoveryStage({
+        await fs.writeFile(
+          path.join(tempDir, '.copytreeinclude'),
+          '# This is a comment\n\n.example/**\n\n# Another comment\n.env\n',
+        );
+
+        const pipeline = new Pipeline();
+        pipeline.through([
+          new FileDiscoveryStage({
+            basePath: tempDir,
+            patterns: ['**/*'],
+            respectGitignore: false,
+            includeHidden: false,
+          }),
+        ]);
+
+        const result = await pipeline.process({
           basePath: tempDir,
-          patterns: ['**/*'],
-          respectGitignore: false,
-          includeHidden: false,
-        }),
-      ]);
+          profile: {},
+          options: {},
+        });
 
-      const result = await pipeline.process({
-        basePath: tempDir,
-        profile: {},
-        options: {},
+        await settleFs();
+
+        const paths = result.files.map((f) => f.path).sort();
+        expect(paths).toContain('.example/secret.txt');
+        expect(paths).toContain('.env');
       });
-
-      const paths = result.files.map((f) => f.path).sort();
-      expect(paths).toContain('.example/secret.txt');
-      expect(paths).toContain('.env');
     });
   });
 
   describe('forceInclude option', () => {
     it('should discover hidden files via forceInclude option', async () => {
-      pipeline.through([
-        new FileDiscoveryStage({
+      await withTempDir('forcinclude-option', async (tempDir) => {
+        await createTestFiles(tempDir);
+
+        const pipeline = new Pipeline();
+        pipeline.through([
+          new FileDiscoveryStage({
+            basePath: tempDir,
+            patterns: ['**/*'],
+            respectGitignore: false,
+            includeHidden: false,
+            forceInclude: ['.example/**', '.env'],
+          }),
+        ]);
+
+        const result = await pipeline.process({
           basePath: tempDir,
-          patterns: ['**/*'],
-          respectGitignore: false,
-          includeHidden: false,
-          forceInclude: ['.example/**', '.env'],
-        }),
-      ]);
+          profile: {},
+          options: {},
+        });
 
-      const result = await pipeline.process({
-        basePath: tempDir,
-        profile: {},
-        options: {},
+        await settleFs();
+
+        const paths = result.files.map((f) => f.path).sort();
+        expect(paths).toContain('.example/secret.txt');
+        expect(paths).toContain('.example/config.json');
+        expect(paths).toContain('.env');
       });
-
-      const paths = result.files.map((f) => f.path).sort();
-      expect(paths).toContain('.example/secret.txt');
-      expect(paths).toContain('.example/config.json');
-      expect(paths).toContain('.env');
     });
 
     it('should merge forceInclude patterns with .copytreeinclude', async () => {
-      await fs.writeFile(path.join(tempDir, '.copytreeinclude'), '.example/**\n');
+      await withTempDir('forcinclude-merge-with-copytreeinclude', async (tempDir) => {
+        await createTestFiles(tempDir);
 
-      pipeline.through([
-        new FileDiscoveryStage({
+        await fs.writeFile(path.join(tempDir, '.copytreeinclude'), '.example/**\n');
+
+        const pipeline = new Pipeline();
+        pipeline.through([
+          new FileDiscoveryStage({
+            basePath: tempDir,
+            patterns: ['**/*'],
+            respectGitignore: false,
+            includeHidden: false,
+            forceInclude: ['.env'], // Add .env via option
+          }),
+        ]);
+
+        const result = await pipeline.process({
           basePath: tempDir,
-          patterns: ['**/*'],
-          respectGitignore: false,
-          includeHidden: false,
-          forceInclude: ['.env'], // Add .env via option
-        }),
-      ]);
+          profile: {},
+          options: {},
+        });
 
-      const result = await pipeline.process({
-        basePath: tempDir,
-        profile: {},
-        options: {},
+        await settleFs();
+
+        const paths = result.files.map((f) => f.path).sort();
+        expect(paths).toContain('.example/secret.txt');
+        expect(paths).toContain('.example/config.json');
+        expect(paths).toContain('.env');
       });
-
-      const paths = result.files.map((f) => f.path).sort();
-      expect(paths).toContain('.example/secret.txt');
-      expect(paths).toContain('.example/config.json');
-      expect(paths).toContain('.env');
     });
   });
 
   describe('AlwaysIncludeStage integration', () => {
     it('should mark force-included files and preserve through profile filters', async () => {
-      await fs.writeFile(path.join(tempDir, '.copytreeinclude'), '.example/**\n');
+      await withTempDir('alwaysinclude-preserve-through-filters', async (tempDir) => {
+        await createTestFiles(tempDir);
 
-      pipeline.through([
-        new FileDiscoveryStage({
+        await fs.writeFile(path.join(tempDir, '.copytreeinclude'), '.example/**\n');
+
+        const pipeline = new Pipeline();
+        pipeline.through([
+          new FileDiscoveryStage({
+            basePath: tempDir,
+            patterns: ['**/*'],
+            respectGitignore: false,
+            includeHidden: false,
+          }),
+          new AlwaysIncludeStage(['.example/**']), // Mark immediately after discovery
+          new ProfileFilterStage({
+            exclude: ['**/*'], // Exclude everything
+          }),
+        ]);
+
+        const result = await pipeline.process({
           basePath: tempDir,
-          patterns: ['**/*'],
-          respectGitignore: false,
-          includeHidden: false,
-        }),
-        new AlwaysIncludeStage(['.example/**']), // Mark immediately after discovery
-        new ProfileFilterStage({
-          exclude: ['**/*'], // Exclude everything
-        }),
-      ]);
+          profile: {},
+          options: {},
+        });
 
-      const result = await pipeline.process({
-        basePath: tempDir,
-        profile: {},
-        options: {},
+        await settleFs();
+
+        const paths = result.files.map((f) => f.path).sort();
+        // Only force-included files should survive
+        expect(paths).toContain('.example/secret.txt');
+        expect(paths).toContain('.example/config.json');
+        expect(paths).not.toContain('index.js');
+        expect(paths).not.toContain('utils.js');
       });
-
-      const paths = result.files.map((f) => f.path).sort();
-      // Only force-included files should survive
-      expect(paths).toContain('.example/secret.txt');
-      expect(paths).toContain('.example/config.json');
-      expect(paths).not.toContain('index.js');
-      expect(paths).not.toContain('utils.js');
     });
 
     it('should preserve force-included files through git filters', async () => {
-      // This test would require setting up a git repository
-      // For now, we'll test the basic flow without actual git operations
-      await fs.writeFile(path.join(tempDir, '.copytreeinclude'), '.example/**\n');
+      await withTempDir('alwaysinclude-preserve-through-git-filters', async (tempDir) => {
+        await createTestFiles(tempDir);
 
-      pipeline.through([
-        new FileDiscoveryStage({
+        // This test would require setting up a git repository
+        // For now, we'll test the basic flow without actual git operations
+        await fs.writeFile(path.join(tempDir, '.copytreeinclude'), '.example/**\n');
+
+        const pipeline = new Pipeline();
+        pipeline.through([
+          new FileDiscoveryStage({
+            basePath: tempDir,
+            patterns: ['**/*'],
+            respectGitignore: false,
+            includeHidden: false,
+          }),
+          new AlwaysIncludeStage(['.example/**']),
+          new ProfileFilterStage({
+            filter: ['*.js'], // Only include JS files
+          }),
+        ]);
+
+        const result = await pipeline.process({
           basePath: tempDir,
-          patterns: ['**/*'],
-          respectGitignore: false,
-          includeHidden: false,
-        }),
-        new AlwaysIncludeStage(['.example/**']),
-        new ProfileFilterStage({
-          filter: ['*.js'], // Only include JS files
-        }),
-      ]);
+          profile: {},
+          options: {},
+        });
 
-      const result = await pipeline.process({
-        basePath: tempDir,
-        profile: {},
-        options: {},
+        await settleFs();
+
+        const paths = result.files.map((f) => f.path).sort();
+        // Should include .js files AND force-included files
+        expect(paths).toContain('index.js');
+        expect(paths).toContain('utils.js');
+        expect(paths).toContain('.example/secret.txt');
+        expect(paths).toContain('.example/config.json');
       });
-
-      const paths = result.files.map((f) => f.path).sort();
-      // Should include .js files AND force-included files
-      expect(paths).toContain('index.js');
-      expect(paths).toContain('utils.js');
-      expect(paths).toContain('.example/secret.txt');
-      expect(paths).toContain('.example/config.json');
     });
   });
 
   describe('deduplication', () => {
     it('should not duplicate files that are both discovered normally and force-included', async () => {
-      pipeline.through([
-        new FileDiscoveryStage({
+      await withTempDir('deduplication-no-duplicates', async (tempDir) => {
+        await createTestFiles(tempDir);
+
+        const pipeline = new Pipeline();
+        pipeline.through([
+          new FileDiscoveryStage({
+            basePath: tempDir,
+            patterns: ['**/*'],
+            respectGitignore: false,
+            includeHidden: true, // Discover all files including hidden
+            forceInclude: ['.example/**'], // Also force-include
+          }),
+        ]);
+
+        const result = await pipeline.process({
           basePath: tempDir,
-          patterns: ['**/*'],
-          respectGitignore: false,
-          includeHidden: true, // Discover all files including hidden
-          forceInclude: ['.example/**'], // Also force-include
-        }),
-      ]);
+          profile: {},
+          options: {},
+        });
 
-      const result = await pipeline.process({
-        basePath: tempDir,
-        profile: {},
-        options: {},
+        await settleFs();
+
+        const paths = result.files.map((f) => f.path);
+        const uniquePaths = [...new Set(paths)];
+
+        // Should have no duplicates
+        expect(paths.length).toBe(uniquePaths.length);
+
+        // Should have all files exactly once
+        expect(paths.filter((p) => p === '.example/secret.txt')).toHaveLength(1);
+        expect(paths.filter((p) => p === '.example/config.json')).toHaveLength(1);
       });
-
-      const paths = result.files.map((f) => f.path);
-      const uniquePaths = [...new Set(paths)];
-
-      // Should have no duplicates
-      expect(paths.length).toBe(uniquePaths.length);
-
-      // Should have all files exactly once
-      expect(paths.filter((p) => p === '.example/secret.txt')).toHaveLength(1);
-      expect(paths.filter((p) => p === '.example/config.json')).toHaveLength(1);
     });
   });
 
   describe('edge cases', () => {
     it('should handle missing .copytreeinclude file gracefully', async () => {
-      pipeline.through([
-        new FileDiscoveryStage({
+      await withTempDir('edge-case-missing-copytreeinclude', async (tempDir) => {
+        await createTestFiles(tempDir);
+
+        const pipeline = new Pipeline();
+        pipeline.through([
+          new FileDiscoveryStage({
+            basePath: tempDir,
+            patterns: ['**/*'],
+            respectGitignore: false,
+            includeHidden: false,
+          }),
+        ]);
+
+        const result = await pipeline.process({
           basePath: tempDir,
-          patterns: ['**/*'],
-          respectGitignore: false,
-          includeHidden: false,
-        }),
-      ]);
+          profile: {},
+          options: {},
+        });
 
-      const result = await pipeline.process({
-        basePath: tempDir,
-        profile: {},
-        options: {},
+        await settleFs();
+
+        // Should discover normal files
+        const paths = result.files.map((f) => f.path).sort();
+        expect(paths).toContain('index.js');
+        expect(paths).toContain('utils.js');
       });
-
-      // Should discover normal files
-      const paths = result.files.map((f) => f.path).sort();
-      expect(paths).toContain('index.js');
-      expect(paths).toContain('utils.js');
     });
 
     it('should handle empty .copytreeinclude file', async () => {
-      await fs.writeFile(path.join(tempDir, '.copytreeinclude'), '');
+      await withTempDir('edge-case-empty-copytreeinclude', async (tempDir) => {
+        await createTestFiles(tempDir);
 
-      pipeline.through([
-        new FileDiscoveryStage({
+        await fs.writeFile(path.join(tempDir, '.copytreeinclude'), '');
+
+        const pipeline = new Pipeline();
+        pipeline.through([
+          new FileDiscoveryStage({
+            basePath: tempDir,
+            patterns: ['**/*'],
+            respectGitignore: false,
+            includeHidden: false,
+          }),
+        ]);
+
+        const result = await pipeline.process({
           basePath: tempDir,
-          patterns: ['**/*'],
-          respectGitignore: false,
-          includeHidden: false,
-        }),
-      ]);
+          profile: {},
+          options: {},
+        });
 
-      const result = await pipeline.process({
-        basePath: tempDir,
-        profile: {},
-        options: {},
+        await settleFs();
+
+        const paths = result.files.map((f) => f.path).sort();
+        expect(paths).toContain('index.js');
+        expect(paths).toContain('utils.js');
       });
-
-      const paths = result.files.map((f) => f.path).sort();
-      expect(paths).toContain('index.js');
-      expect(paths).toContain('utils.js');
     });
 
     it('should handle .copytreeinclude with only comments', async () => {
-      await fs.writeFile(
-        path.join(tempDir, '.copytreeinclude'),
-        '# Comment 1\n# Comment 2\n\n# Comment 3',
-      );
+      await withTempDir('edge-case-copytreeinclude-comments-only', async (tempDir) => {
+        await createTestFiles(tempDir);
 
-      pipeline.through([
-        new FileDiscoveryStage({
+        await fs.writeFile(
+          path.join(tempDir, '.copytreeinclude'),
+          '# Comment 1\n# Comment 2\n\n# Comment 3',
+        );
+
+        const pipeline = new Pipeline();
+        pipeline.through([
+          new FileDiscoveryStage({
+            basePath: tempDir,
+            patterns: ['**/*'],
+            respectGitignore: false,
+            includeHidden: false,
+          }),
+        ]);
+
+        const result = await pipeline.process({
           basePath: tempDir,
-          patterns: ['**/*'],
-          respectGitignore: false,
-          includeHidden: false,
-        }),
-      ]);
+          profile: {},
+          options: {},
+        });
 
-      const result = await pipeline.process({
-        basePath: tempDir,
-        profile: {},
-        options: {},
+        await settleFs();
+
+        const paths = result.files.map((f) => f.path).sort();
+        expect(paths).toContain('index.js');
+        expect(paths).toContain('utils.js');
       });
-
-      const paths = result.files.map((f) => f.path).sort();
-      expect(paths).toContain('index.js');
-      expect(paths).toContain('utils.js');
     });
 
     it('should handle patterns that match no files', async () => {
-      await fs.writeFile(path.join(tempDir, '.copytreeinclude'), 'nonexistent/**\n');
+      await withTempDir('edge-case-no-matching-patterns', async (tempDir) => {
+        await createTestFiles(tempDir);
 
-      pipeline.through([
-        new FileDiscoveryStage({
+        await fs.writeFile(path.join(tempDir, '.copytreeinclude'), 'nonexistent/**\n');
+
+        const pipeline = new Pipeline();
+        pipeline.through([
+          new FileDiscoveryStage({
+            basePath: tempDir,
+            patterns: ['**/*'],
+            respectGitignore: false,
+            includeHidden: false,
+          }),
+        ]);
+
+        const result = await pipeline.process({
           basePath: tempDir,
-          patterns: ['**/*'],
-          respectGitignore: false,
-          includeHidden: false,
-        }),
-      ]);
+          profile: {},
+          options: {},
+        });
 
-      const result = await pipeline.process({
-        basePath: tempDir,
-        profile: {},
-        options: {},
+        await settleFs();
+
+        // Should not throw errors, just not find any forced files
+        const paths = result.files.map((f) => f.path).sort();
+        expect(paths).toContain('index.js');
+        expect(paths).toContain('utils.js');
       });
-
-      // Should not throw errors, just not find any forced files
-      const paths = result.files.map((f) => f.path).sort();
-      expect(paths).toContain('index.js');
-      expect(paths).toContain('utils.js');
     });
   });
 });

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -1,0 +1,17 @@
+/**
+ * Jest setup file for additional configuration
+ *
+ * This file is executed after the test framework is installed
+ * but before each test file is executed.
+ */
+
+// Enable test retries in CI environment only
+if (process.env.CI) {
+  // Retry failed tests once in CI to handle transient issues
+  // Log errors before retry for debugging
+  jest.retryTimes(1, { logErrorsBeforeRetry: true });
+}
+
+// Always use real timers (not fake timers)
+// This is important for tempfs.js settling logic
+jest.useRealTimers();

--- a/tests/unit/config/ConfigManager.test.js
+++ b/tests/unit/config/ConfigManager.test.js
@@ -6,8 +6,9 @@ jest.mock('../../../src/config.js', () => import('../../mocks/config.js'));
 
 // Static imports for Node.js modules
 import fs from 'fs-extra';
-import path from 'path';
-import os from 'os';
+
+// Import temp file management helpers
+import { withTempDir, settleFs } from '../../helpers/tempfs.js';
 
 // Use dynamic import for module under test
 let config, env;
@@ -19,16 +20,14 @@ beforeAll(async () => {
 });
 
 describe('ConfigManager', () => {
-  let tempDir;
   let originalEnv;
 
   beforeEach(() => {
     jest.clearAllMocks();
     originalEnv = { ...process.env };
-    tempDir = path.join(os.tmpdir(), `copytree-test-${Date.now()}`);
 
     // Mock file system operations
-    fs.mkdtempSync.mockReturnValue(tempDir);
+    fs.mkdtempSync.mockReturnValue('/mocked-temp');
     fs.existsSync.mockReturnValue(false);
     fs.ensureDirSync.mockImplementation(() => {});
     fs.readdirSync.mockReturnValue([]);

--- a/tests/unit/pipeline/stages/OutputFormattingStage.test.js
+++ b/tests/unit/pipeline/stages/OutputFormattingStage.test.js
@@ -3,7 +3,7 @@ jest.unmock('fs-extra');
 
 import fs from 'fs-extra';
 import path from 'path';
-import os from 'os';
+import { withTempDir, settleFs } from '../../../helpers/tempfs.js';
 
 let OutputFormattingStage;
 let config;
@@ -16,209 +16,212 @@ beforeAll(async () => {
 });
 
 describe('OutputFormattingStage - Markdown', () => {
-  let tempDir;
-
-  beforeEach(async () => {
-    tempDir = path.join(os.tmpdir(), `ct-md-${Date.now()}`);
-    await fs.ensureDir(tempDir);
-  });
-
-  afterEach(async () => {
-    await fs.remove(tempDir);
-  });
-
   it('renders front matter, tree and one file with markers', async () => {
-    const filePath = path.join(tempDir, 'index.js');
-    await fs.writeFile(filePath, 'console.log("hi");');
+    await withTempDir('md-front-matter', async (tempDir) => {
+      const filePath = path.join(tempDir, 'index.js');
+      await fs.writeFile(filePath, 'console.log("hi");');
 
-    const stage = new OutputFormattingStage({ format: 'markdown' });
-    const result = await stage.process({
-      basePath: tempDir,
-      profile: { name: 'default' },
-      options: {},
-      files: [
-        {
-          path: 'index.js',
-          absolutePath: filePath,
-          size: 18,
-          modified: new Date(),
-          isBinary: false,
-          content: 'console.log("hi");',
-        },
-      ],
+      const stage = new OutputFormattingStage({ format: 'markdown' });
+      const result = await stage.process({
+        basePath: tempDir,
+        profile: { name: 'default' },
+        options: {},
+        files: [
+          {
+            path: 'index.js',
+            absolutePath: filePath,
+            size: 18,
+            modified: new Date(),
+            isBinary: false,
+            content: 'console.log("hi");',
+          },
+        ],
+      });
+
+      const out = result.output;
+      expect(out.startsWith('---')).toBe(true);
+      expect(out).toContain('format: copytree-md@1');
+      expect(out).toContain('# CopyTree Export');
+      expect(out).toContain('## Directory Tree');
+      expect(out).toMatch(/<!--\s*copytree:file-begin[^>]*-->/);
+      expect(out).toMatch(/<!--\s*copytree:file-end\s+path="@index\.js"\s*-->/);
+      expect(out).toContain('```js');
     });
-
-    const out = result.output;
-    expect(out.startsWith('---')).toBe(true);
-    expect(out).toContain('format: copytree-md@1');
-    expect(out).toContain('# CopyTree Export');
-    expect(out).toContain('## Directory Tree');
-    expect(out).toMatch(/<!--\s*copytree:file-begin[^>]*-->/);
-    expect(out).toMatch(/<!--\s*copytree:file-end\s+path="@index\.js"\s*-->/);
-    expect(out).toContain('```js');
   });
 
   it('uses longer fence when content contains backticks', async () => {
-    const filePath = path.join(tempDir, 'README.md');
-    await fs.writeFile(filePath, 'Here is code:\n```\nconsole.log(1)\n```');
+    await withTempDir('md-longer-fence', async (tempDir) => {
+      const filePath = path.join(tempDir, 'README.md');
+      await fs.writeFile(filePath, 'Here is code:\n```\nconsole.log(1)\n```');
 
-    const stage = new OutputFormattingStage({ format: 'markdown' });
-    const result = await stage.process({
-      basePath: tempDir,
-      profile: { name: 'default' },
-      options: {},
-      files: [
-        {
-          path: 'README.md',
-          absolutePath: filePath,
-          size: 32,
-          modified: new Date(),
-          isBinary: false,
-          content: 'Here is code:\n```\nconsole.log(1)\n```',
-        },
-      ],
+      const stage = new OutputFormattingStage({ format: 'markdown' });
+      const result = await stage.process({
+        basePath: tempDir,
+        profile: { name: 'default' },
+        options: {},
+        files: [
+          {
+            path: 'README.md',
+            absolutePath: filePath,
+            size: 32,
+            modified: new Date(),
+            isBinary: false,
+            content: 'Here is code:\n```\nconsole.log(1)\n```',
+          },
+        ],
+      });
+
+      const out = result.output;
+      // Look for a 4 backtick fence
+      expect(out).toContain('````markdown');
     });
-
-    const out = result.output;
-    // Look for a 4 backtick fence
-    expect(out).toContain('````markdown');
   });
 
   it('handles binary placeholder mode', async () => {
-    // Configure placeholder
-    config().set('copytree.binaryFileAction', 'placeholder');
-    config().set('copytree.binaryPlaceholderText', '[Binary file not included]');
+    await withTempDir('md-binary-placeholder', async (tempDir) => {
+      // Configure placeholder
+      config().set('copytree.binaryFileAction', 'placeholder');
+      config().set('copytree.binaryPlaceholderText', '[Binary file not included]');
 
-    const filePath = path.join(tempDir, 'image.png');
-    await fs.writeFile(filePath, Buffer.from([1, 2, 3, 4]));
+      const filePath = path.join(tempDir, 'image.png');
+      await fs.writeFile(filePath, Buffer.from([1, 2, 3, 4]));
 
-    const stage = new OutputFormattingStage({ format: 'markdown' });
-    const result = await stage.process({
-      basePath: tempDir,
-      profile: { name: 'default' },
-      options: {},
-      files: [
-        {
-          path: 'image.png',
-          absolutePath: filePath,
-          size: 4,
-          modified: new Date(),
-          isBinary: true,
-          content: '[Binary file not included]',
-        },
-      ],
+      const stage = new OutputFormattingStage({ format: 'markdown' });
+      const result = await stage.process({
+        basePath: tempDir,
+        profile: { name: 'default' },
+        options: {},
+        files: [
+          {
+            path: 'image.png',
+            absolutePath: filePath,
+            size: 4,
+            modified: new Date(),
+            isBinary: true,
+            content: '[Binary file not included]',
+          },
+        ],
+      });
+
+      const out = result.output;
+      expect(out).toMatch(/binary=(\"?true\"?)/);
+      expect(out).toContain('[Binary file not included]');
     });
-
-    const out = result.output;
-    expect(out).toMatch(/binary=(\"?true\"?)/);
-    expect(out).toContain('[Binary file not included]');
   });
 
   it('handles binary base64 mode', async () => {
-    // Configure base64
-    config().set('copytree.binaryFileAction', 'base64');
+    await withTempDir('md-binary-base64', async (tempDir) => {
+      // Configure base64
+      config().set('copytree.binaryFileAction', 'base64');
 
-    const filePath = path.join(tempDir, 'blob.bin');
-    const data = Buffer.from('hello');
-    await fs.writeFile(filePath, data);
+      const filePath = path.join(tempDir, 'blob.bin');
+      const data = Buffer.from('hello');
+      await fs.writeFile(filePath, data);
 
-    const stage = new OutputFormattingStage({ format: 'markdown' });
-    const base64 = data.toString('base64');
-    const result = await stage.process({
-      basePath: tempDir,
-      profile: { name: 'default' },
-      options: {},
-      files: [
-        {
-          path: 'blob.bin',
-          absolutePath: filePath,
-          size: data.length,
-          modified: new Date(),
-          isBinary: true,
-          encoding: 'base64',
-          content: base64,
-        },
-      ],
+      const stage = new OutputFormattingStage({ format: 'markdown' });
+      const base64 = data.toString('base64');
+      const result = await stage.process({
+        basePath: tempDir,
+        profile: { name: 'default' },
+        options: {},
+        files: [
+          {
+            path: 'blob.bin',
+            absolutePath: filePath,
+            size: data.length,
+            modified: new Date(),
+            isBinary: true,
+            encoding: 'base64',
+            content: base64,
+          },
+        ],
+      });
+
+      const out = result.output;
+      expect(out).toContain('Content-Transfer: base64');
+      expect(out).toContain(base64);
     });
-
-    const out = result.output;
-    expect(out).toContain('Content-Transfer: base64');
-    expect(out).toContain(base64);
   });
 
   it('adds line numbers when enabled', async () => {
-    const stage = new OutputFormattingStage({ format: 'markdown', addLineNumbers: true });
-    const filePath = path.join(tempDir, 'a.js');
-    await fs.writeFile(filePath, 'a\nb');
-    const result = await stage.process({
-      basePath: tempDir,
-      profile: { name: 'default' },
-      options: { withLineNumbers: true },
-      files: [
-        {
-          path: 'a.js',
-          absolutePath: filePath,
-          size: 3,
-          modified: new Date(),
-          isBinary: false,
-          content: 'a\nb',
-        },
-      ],
+    await withTempDir('md-line-numbers', async (tempDir) => {
+      const stage = new OutputFormattingStage({ format: 'markdown', addLineNumbers: true });
+      const filePath = path.join(tempDir, 'a.js');
+      await fs.writeFile(filePath, 'a\nb');
+      const result = await stage.process({
+        basePath: tempDir,
+        profile: { name: 'default' },
+        options: { withLineNumbers: true },
+        files: [
+          {
+            path: 'a.js',
+            absolutePath: filePath,
+            size: 3,
+            modified: new Date(),
+            isBinary: false,
+            content: 'a\nb',
+          },
+        ],
+      });
+      const out = result.output;
+      expect(out).toMatch(/\n\s*1\s*:/);
+      expect(out).toMatch(/\n\s*2\s*:/);
     });
-    const out = result.output;
-    expect(out).toMatch(/\n\s*1\s*:/);
-    expect(out).toMatch(/\n\s*2\s*:/);
   });
 
   it('includes instructions with markers', async () => {
-    const stage = new OutputFormattingStage({ format: 'markdown' });
-    const filePath = path.join(tempDir, 'x.txt');
-    await fs.writeFile(filePath, 'x');
-    const result = await stage.process({
-      basePath: tempDir,
-      profile: { name: 'default' },
-      options: { instructions: 'default' },
-      instructions: 'Read carefully',
-      instructionsName: 'default',
-      files: [
-        {
-          path: 'x.txt',
-          absolutePath: filePath,
-          size: 1,
-          modified: new Date(),
-          isBinary: false,
-          content: 'x',
-        },
-      ],
+    await withTempDir('md-instructions', async (tempDir) => {
+      const stage = new OutputFormattingStage({ format: 'markdown' });
+      const filePath = path.join(tempDir, 'x.txt');
+      await fs.writeFile(filePath, 'x');
+      const result = await stage.process({
+        basePath: tempDir,
+        profile: { name: 'default' },
+        options: { instructions: 'default' },
+        instructions: 'Read carefully',
+        instructionsName: 'default',
+        files: [
+          {
+            path: 'x.txt',
+            absolutePath: filePath,
+            size: 1,
+            modified: new Date(),
+            isBinary: false,
+            content: 'x',
+          },
+        ],
+      });
+      const out = result.output;
+      expect(out).toContain('## Instructions');
+      expect(out).toContain('<!-- copytree:instructions-begin');
+      expect(out).toContain('<!-- copytree:instructions-end');
     });
-    const out = result.output;
-    expect(out).toContain('## Instructions');
-    expect(out).toContain('<!-- copytree:instructions-begin');
-    expect(out).toContain('<!-- copytree:instructions-end');
   });
 
   it('emits truncation markers for truncated files', async () => {
-    const stage = new OutputFormattingStage({ format: 'markdown' });
-    const filePath = path.join(tempDir, 'big.txt');
-    await fs.writeFile(filePath, 'abcdefg');
-    const result = await stage.process({
-      basePath: tempDir,
-      profile: { name: 'default' },
-      options: {},
-      files: [
-        {
-          path: 'big.txt',
-          absolutePath: filePath,
-          size: 7,
-          modified: new Date(),
-          isBinary: false,
-          content: 'abc',
-          originalLength: 7,
-          truncated: true,
-        },
-      ],
+    await withTempDir('md-truncation-markers', async (tempDir) => {
+      const stage = new OutputFormattingStage({ format: 'markdown' });
+      const filePath = path.join(tempDir, 'big.txt');
+      await fs.writeFile(filePath, 'abcdefg');
+      const result = await stage.process({
+        basePath: tempDir,
+        profile: { name: 'default' },
+        options: {},
+        files: [
+          {
+            path: 'big.txt',
+            absolutePath: filePath,
+            size: 7,
+            modified: new Date(),
+            isBinary: false,
+            content: 'abc',
+            originalLength: 7,
+            truncated: true,
+          },
+        ],
+      });
+      const out = result.output;
+      expect(out).toContain('copytree:truncated');
     });
-    const out = result.output;
-    expect(out).toContain('copytree:truncated');
   });
 });

--- a/tests/unit/utils/ignoreWalker.test.js
+++ b/tests/unit/utils/ignoreWalker.test.js
@@ -1,21 +1,10 @@
 import path from 'path';
 import { promises as fs } from 'fs';
-import os from 'os';
+import { withTempDir, settleFs } from '../../helpers/tempfs.js';
 import { getAllFiles } from '../../../src/utils/ignoreWalker.js';
 
 describe('ignoreWalker', () => {
-  let tempDir;
-
-  beforeEach(async () => {
-    const tempPath = path.join(os.tmpdir(), 'ignore-walker-');
-    tempDir = await fs.mkdtemp(tempPath);
-  });
-
-  afterEach(async () => {
-    await fs.rm(tempDir, { recursive: true, force: true });
-  });
-
-  const createProject = async (files) => {
+  const createProject = async (tempDir, files) => {
     const allPaths = [];
     for (const [file, content] of Object.entries(files)) {
       const filePath = path.join(tempDir, file);
@@ -28,109 +17,130 @@ describe('ignoreWalker', () => {
     return allPaths;
   };
 
-  const getIgnored = async (allFiles, options) => {
+  const getIgnored = async (tempDir, allFiles, options) => {
     const keptFiles = await getAllFiles(tempDir, options);
     const keptPaths = new Set(keptFiles.map((f) => f.path));
     return allFiles.filter((f) => !keptPaths.has(f));
   };
 
   it('should ignore a file specified in .copytreeignore', async () => {
-    const allFiles = await createProject({
-      '.copytreeignore': 'a.txt',
-      'a.txt': 'a',
-      'b.txt': 'b',
-    });
+    await withTempDir('ignore-basic-file', async (tempDir) => {
+      const allFiles = await createProject(tempDir, {
+        '.copytreeignore': 'a.txt',
+        'a.txt': 'a',
+        'b.txt': 'b',
+      });
 
-    const ignored = await getIgnored(allFiles);
-    expect(ignored).toEqual([path.join(tempDir, 'a.txt')]);
+      await settleFs(50);
+      const ignored = await getIgnored(tempDir, allFiles);
+      expect(ignored).toEqual([path.join(tempDir, 'a.txt')]);
+    });
   });
 
   it('should handle nested .copytreeignore files', async () => {
-    const allFiles = await createProject({
-      '.copytreeignore': 'a.txt',
-      'nested/a.txt': 'a',
-      'nested/.copytreeignore': 'b.txt',
-      'nested/b.txt': 'b',
-      'nested/c.txt': 'c',
-      'b.txt': 'b-root',
+    await withTempDir('ignore-nested-files', async (tempDir) => {
+      const allFiles = await createProject(tempDir, {
+        '.copytreeignore': 'a.txt',
+        'nested/a.txt': 'a',
+        'nested/.copytreeignore': 'b.txt',
+        'nested/b.txt': 'b',
+        'nested/c.txt': 'c',
+        'b.txt': 'b-root',
+      });
+
+      await settleFs(50);
+      const ignored = await getIgnored(tempDir, allFiles);
+      const expected = [
+        path.join(tempDir, 'nested/a.txt'),
+        path.join(tempDir, 'nested/b.txt'),
+      ].sort();
+
+      const ignoredPaths = ignored.map((p) => path.join(p));
+      expect(ignoredPaths.sort()).toEqual(expected);
     });
-
-    const ignored = await getIgnored(allFiles);
-    const expected = [
-      path.join(tempDir, 'nested/a.txt'),
-      path.join(tempDir, 'nested/b.txt'),
-    ].sort();
-
-    const ignoredPaths = ignored.map((p) => path.join(p));
-    expect(ignoredPaths.sort()).toEqual(expected);
   });
 
   it('should handle negations in ignore files', async () => {
-    const allFiles = await createProject({
-      '.copytreeignore': `*.log
+    await withTempDir('ignore-negations', async (tempDir) => {
+      const allFiles = await createProject(tempDir, {
+        '.copytreeignore': `*.log
 !important.log`,
-      'a.log': 'a',
-      'important.log': 'important',
-    });
+        'a.log': 'a',
+        'important.log': 'important',
+      });
 
-    const ignored = await getIgnored(allFiles);
-    expect(ignored).toEqual([path.join(tempDir, 'a.log')]);
+      await settleFs(50);
+      const ignored = await getIgnored(tempDir, allFiles);
+      expect(ignored).toEqual([path.join(tempDir, 'a.log')]);
+    });
   });
 
   it('should use .gitignore when specified', async () => {
-    const allFiles = await createProject({
-      '.gitignore': 'a.txt',
-      'a.txt': 'a',
-      'b.txt': 'b',
-    });
+    await withTempDir('ignore-gitignore-file', async (tempDir) => {
+      const allFiles = await createProject(tempDir, {
+        '.gitignore': 'a.txt',
+        'a.txt': 'a',
+        'b.txt': 'b',
+      });
 
-    const ignored = await getIgnored(allFiles, { ignoreFileName: '.gitignore' });
-    expect(ignored).toEqual([path.join(tempDir, 'a.txt')]);
+      await settleFs(50);
+      const ignored = await getIgnored(tempDir, allFiles, { ignoreFileName: '.gitignore' });
+      expect(ignored).toEqual([path.join(tempDir, 'a.txt')]);
+    });
   });
 
   it('should prefer .copytreeignore over .gitignore if both exist and .copytreeignore is default', async () => {
-    const allFiles = await createProject({
-      '.gitignore': 'a.txt',
-      '.copytreeignore': 'b.txt',
-      'a.txt': 'a',
-      'b.txt': 'b',
-    });
+    await withTempDir('ignore-preference-copytreeignore', async (tempDir) => {
+      const allFiles = await createProject(tempDir, {
+        '.gitignore': 'a.txt',
+        '.copytreeignore': 'b.txt',
+        'a.txt': 'a',
+        'b.txt': 'b',
+      });
 
-    const ignored = await getIgnored(allFiles);
-    expect(ignored).toEqual([path.join(tempDir, 'b.txt')]);
+      await settleFs(50);
+      const ignored = await getIgnored(tempDir, allFiles);
+      expect(ignored).toEqual([path.join(tempDir, 'b.txt')]);
+    });
   });
 
   it('should ignore entire directories', async () => {
-    const allFiles = await createProject({
-      '.copytreeignore': 'node_modules/',
-      'node_modules/a.js': 'a',
-      'src/index.js': 'index',
-    });
+    await withTempDir('ignore-entire-directories', async (tempDir) => {
+      const allFiles = await createProject(tempDir, {
+        '.copytreeignore': 'node_modules/',
+        'node_modules/a.js': 'a',
+        'src/index.js': 'index',
+      });
 
-    const ignored = await getIgnored(allFiles);
-    expect(ignored).toEqual([path.join(tempDir, 'node_modules/a.js')]);
+      await settleFs(50);
+      const ignored = await getIgnored(tempDir, allFiles);
+      expect(ignored).toEqual([path.join(tempDir, 'node_modules/a.js')]);
+    });
   });
 
   it('should handle complex nested rules and negations', async () => {
-    const allFiles = await createProject({
-      '.copytreeignore': `logs/
+    await withTempDir('ignore-complex-nested-rules', async (tempDir) => {
+      const allFiles = await createProject(tempDir, {
+        '.copytreeignore': `logs/
 !logs/important.log`,
-      'logs/a.log': 'a',
-      'logs/important.log': 'important',
-      'src/index.js': 'index',
-      'src/feature/.copytreeignore': `*.js
+        'logs/a.log': 'a',
+        'logs/important.log': 'important',
+        'src/index.js': 'index',
+        'src/feature/.copytreeignore': `*.js
 !feature.js`,
-      'src/feature/feature.js': 'feature',
-      'src/feature/utils.js': 'utils',
+        'src/feature/feature.js': 'feature',
+        'src/feature/utils.js': 'utils',
+      });
+
+      await settleFs(50);
+      const ignored = await getIgnored(tempDir, allFiles);
+      const expected = [
+        path.join(tempDir, 'logs/a.log'),
+        path.join(tempDir, 'logs/important.log'),
+        path.join(tempDir, 'src/feature/utils.js'),
+      ].sort();
+
+      expect(ignored.sort()).toEqual(expected);
     });
-
-    const ignored = await getIgnored(allFiles);
-    const expected = [
-      path.join(tempDir, 'logs/a.log'),
-      path.join(tempDir, 'logs/important.log'),
-      path.join(tempDir, 'src/feature/utils.js'),
-    ].sort();
-
-    expect(ignored.sort()).toEqual(expected);
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes intermittent Jest test failures (issue #18) caused by asynchronous filesystem cleanup race conditions. Tests were failing with `ENOENT` (file not found) and `ENOTEMPTY` (directory not empty) errors when `afterEach()` cleanup executed before all async file operations completed.

The solution implements a centralized `tempfs` helper with robust cleanup, retry logic, and macOS/APFS optimizations to ensure deterministic test execution.

Closes #18

## Changes Made

- Add centralized tempfs helper with robust cleanup and retry logic
- Implement withTempDir pattern for deterministic temporary directories
- Add settleFs function to wait for filesystem operations to complete
- Create safeRemove with exponential backoff for ENOTEMPTY/EBUSY errors
- Disable macOS Spotlight indexing on test directories with .metadata_never_index
- Refactor 8 test files (97 tests) to use new tempfs helper
- Add jest.setup.js for CI retry configuration and real timer enforcement
- Update jest.config.js with coverage thresholds and setup file
- Deprecate legacy temp directory functions in fixtures.js
- Use unique temp directory naming with PID, worker ID, timestamp, and UUID

## Test Results

### Before Fix
- **Intermittent failures**: 0-2 random test failures per run
- **Error types**: `ENOENT: no such file or directory`, `ENOTEMPTY: directory not empty`
- **Root cause**: `afterEach()` cleanup executing before async file operations completed

### After Fix
- **✅ 100% pass rate** on refactored tests (97 tests across 8 files)
- **✅ No ENOENT/ENOTEMPTY errors** in any refactored tests
- **✅ Deterministic cleanup** with retry logic and exponential backoff
- **✅ macOS/APFS optimized** with Spotlight indexing disabled

### Stability Testing
Ran originally problematic tests 10 consecutive times:
- `tests/integration/pipeline.test.js` (17 tests): **10/10 runs = 100% pass rate**
- `tests/unit/.../FileDiscoveryStage.copytreeinclude.test.js` (13 tests): **10/10 runs = 100% pass rate**

## Files Modified

**New Files:**
- `tests/helpers/tempfs.js` - Centralized temp filesystem management
- `tests/jest.setup.js` - Jest configuration for CI retries

**Refactored Test Files (8 files, 97 tests):**
- `tests/integration/pipeline.test.js` (17 tests)
- `tests/unit/pipeline/stages/FileDiscoveryStage.copytreeinclude.test.js` (13 tests)
- `tests/integration/forceInclude.test.js` (13 tests)
- `tests/unit/pipeline/stages/OutputFormattingStage.test.js` (7 tests)
- `tests/unit/config/ConfigManager.test.js` (12 tests)
- `tests/unit/utils/ignoreWalker.test.js` (7 tests)
- `tests/unit/services/CacheService.test.js` (10 tests)
- `tests/integration/commands.test.js` (18 tests)

**Configuration:**
- `jest.config.js` - Added coverage thresholds and setup file
- `tests/helpers/fixtures.js` - Deprecated legacy temp functions

## Key Features

### Robust Cleanup
- Automatic cleanup via `withTempDir()` even if tests fail
- Retry logic with exponential backoff (100ms → 200ms → 400ms → 500ms)
- Handles `ENOTEMPTY` and `EBUSY` errors gracefully

### macOS/APFS Optimization
- Disables Spotlight indexing with `.metadata_never_index`
- 50ms filesystem settling delay for cache flush
- Handles APFS transient states

### Test Isolation
- Unique temp directories per test: `<tmpdir>/copytree-tests/<PID>-<WORKER>-<timestamp>-<uuid>/<label>/`
- No global state or shared temp directories
- Each test creates fresh pipeline/stage instances

## Performance Impact

- Minimal overhead: ~50ms per test for filesystem settling
- Well within the <5% acceptance criteria
- No regression in test execution time