### PR TITLE
fix(clipboard): fix Windows escaping, macOS/Linux shell injection, and Clipboard.copy typo

### DIFF
--- a/src/api/copy.js
+++ b/src/api/copy.js
@@ -185,7 +185,7 @@ export async function copy(basePath, options = {}) {
   // Copy to clipboard if explicitly requested
   if (options.clipboard) {
     try {
-      await Clipboard.copy(output);
+      await Clipboard.copyText(output);
     } catch (error) {
       // Don't fail the operation if clipboard copy fails
       result.stats.clipboardError = error.message;

--- a/src/utils/clipboard.js
+++ b/src/utils/clipboard.js
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 import process from 'process';
 import url from 'url';
 import path from 'path';
@@ -27,9 +27,21 @@ class Clipboard {
   static async copyFileReference(filePath) {
     if (process.platform === 'win32') {
       try {
-        // Use PowerShell to copy the file reference on Windows
-        const command = `powershell -Command "Set-Clipboard -Path '${filePath.replace(/'/g, "''")}'"`;
-        execSync(command, { stdio: 'pipe' });
+        // Use Windows Forms SetFileDropList via Base64-encoded PowerShell command.
+        // This bypasses all shell quoting (Base64 encoding) and path glob expansion
+        // (StringCollection is passed to SetFileDropList without any wildcard interpretation).
+        // Single quotes are doubled for the PS single-quoted string literal.
+        const psPath = filePath.replace(/'/g, "''");
+        const psCommand = [
+          'Add-Type -AssemblyName System.Windows.Forms',
+          '$fc = New-Object System.Collections.Specialized.StringCollection',
+          `[void]$fc.Add('${psPath}')`,
+          '[System.Windows.Forms.Clipboard]::SetFileDropList($fc)',
+        ].join('; ');
+        const encoded = Buffer.from(psCommand, 'utf16le').toString('base64');
+        execSync(`powershell -NoProfile -NonInteractive -EncodedCommand ${encoded}`, {
+          stdio: 'pipe',
+        });
       } catch (error) {
         logger.debug(
           'Failed to copy file reference using PowerShell, falling back to text:',
@@ -48,17 +60,13 @@ class Clipboard {
       }
     } else if (process.platform === 'darwin') {
       try {
-        // Use AppleScript to copy file reference
+        // Use AppleScript to copy file reference. spawnSync passes the script as a
+        // direct argument (no shell), so single quotes in filePath are safe.
         const escapedFilePath = filePath.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-        const script = `
-          set aFile to POSIX file "${escapedFilePath}"
-          tell app "Finder" to set the clipboard to aFile
-        `.trim();
+        const script = `set aFile to POSIX file "${escapedFilePath}"
+tell app "Finder" to set the clipboard to aFile`;
 
-        execSync(`osascript -e '${script}'`, {
-          encoding: 'utf8',
-          stdio: 'pipe',
-        });
+        spawnSync('osascript', ['-e', script], { encoding: 'utf8', stdio: 'pipe' });
       } catch (error) {
         logger.debug('Failed to copy file reference, falling back to text:', error.message);
         // Fallback to copying path as text
@@ -78,30 +86,28 @@ class Clipboard {
   static async revealInFinder(filePath) {
     if (process.platform === 'win32') {
       try {
-        execSync(`explorer /select,"${filePath}"`, { stdio: 'pipe' });
+        // Use spawnSync with array args to avoid cmd.exe interpreting &, |, <, >, ^ in paths
+        spawnSync('explorer', [`/select,${filePath}`], { stdio: 'pipe' });
       } catch (error) {
         logger.debug('Failed to reveal file in Explorer:', error.message);
       }
     } else if (process.platform === 'linux') {
       try {
-        // Use xdg-open to open the parent directory
+        // Use spawnSync with array args to avoid shell interpreting $, ", ` in paths
         const dir = path.dirname(filePath);
-        execSync(`xdg-open "${dir}"`, { stdio: 'pipe' });
+        spawnSync('xdg-open', [dir], { stdio: 'pipe' });
       } catch (error) {
         logger.debug('Failed to reveal file with xdg-open:', error.message);
       }
     } else if (process.platform === 'darwin') {
       try {
-        const escapedFilePath = filePath.replace(/"/g, '"');
-        const script = `
-          tell application "Finder" to reveal POSIX file "${escapedFilePath}"
-          tell application "Finder" to activate
-        `.trim();
+        // Use AppleScript to reveal file. spawnSync passes the script as a direct
+        // argument (no shell), so single quotes in filePath are safe.
+        const escapedFilePath = filePath.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+        const script = `tell application "Finder" to reveal POSIX file "${escapedFilePath}"
+tell application "Finder" to activate`;
 
-        execSync(`osascript -e '${script}'`, {
-          encoding: 'utf8',
-          stdio: 'pipe',
-        });
+        spawnSync('osascript', ['-e', script], { encoding: 'utf8', stdio: 'pipe' });
       } catch (error) {
         logger.debug('Failed to reveal file in Finder:', error.message);
       }

--- a/tests/setup-global-mocks.js
+++ b/tests/setup-global-mocks.js
@@ -225,13 +225,19 @@ jest.mock('../src/utils/logger.js', () => ({
   logger: mockLogger,
 }));
 
-// Mock clipboardy to prevent ESM import issues
-jest.mock('clipboardy', () => ({
-  write: jest.fn().mockResolvedValue(undefined),
-  read: jest.fn().mockResolvedValue(''),
-  writeSync: jest.fn(),
-  readSync: jest.fn().mockReturnValue(''),
-}));
+// Mock clipboardy to prevent ESM import issues.
+// The mock object is set as its own `.default` so that dynamic ESM imports
+// (`const { default: clipboardy } = await import('clipboardy')`) resolve correctly.
+jest.mock('clipboardy', () => {
+  const mock = {
+    write: jest.fn().mockResolvedValue(undefined),
+    read: jest.fn().mockResolvedValue(''),
+    writeSync: jest.fn(),
+    readSync: jest.fn().mockReturnValue(''),
+  };
+  mock.default = mock;
+  return mock;
+});
 
 // Mock fs-extra (comprehensive mock with all functions)
 jest.mock('fs-extra', () => {

--- a/tests/unit/utils/clipboard.test.js
+++ b/tests/unit/utils/clipboard.test.js
@@ -1,0 +1,254 @@
+import { execSync, spawnSync } from 'child_process';
+import Clipboard from '../../../src/utils/clipboard.js';
+
+jest.mock('child_process', () => ({
+  execSync: jest.fn(),
+  spawnSync: jest.fn(),
+}));
+
+// Platform switching helper
+const originalPlatform = process.platform;
+function setPlatform(platform) {
+  Object.defineProperty(process, 'platform', { value: platform, writable: true });
+}
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true });
+});
+
+describe('Clipboard', () => {
+  describe('copyText', () => {
+    it('copies text via clipboardy', async () => {
+      await Clipboard.copyText('hello');
+      const { default: clipboardy } = await import('clipboardy');
+      expect(clipboardy.write).toHaveBeenCalledWith('hello');
+      expect(clipboardy.write).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('copyFileReference — Windows', () => {
+    beforeEach(() => setPlatform('win32'));
+
+    it('uses Base64-encoded PowerShell command via EncodedCommand', async () => {
+      await Clipboard.copyFileReference('C:\\Users\\test\\output.xml');
+
+      expect(execSync).toHaveBeenCalledTimes(1);
+      const [cmd] = execSync.mock.calls[0];
+      expect(cmd).toMatch(/^powershell -NoProfile -NonInteractive -EncodedCommand /);
+    });
+
+    it('uses Windows Forms SetFileDropList (no glob expansion)', async () => {
+      await Clipboard.copyFileReference('C:\\Users\\test\\output.xml');
+
+      const [cmd] = execSync.mock.calls[0];
+      const base64 = cmd.split('-EncodedCommand ')[1];
+      const decoded = Buffer.from(base64, 'base64').toString('utf16le');
+      expect(decoded).toContain('SetFileDropList');
+      expect(decoded).toContain('System.Windows.Forms');
+    });
+
+    it('escapes single quotes by doubling them', async () => {
+      await Clipboard.copyFileReference("C:\\Users\\it's a test\\file.xml");
+
+      const [cmd] = execSync.mock.calls[0];
+      const base64 = cmd.split('-EncodedCommand ')[1];
+      const decoded = Buffer.from(base64, 'base64').toString('utf16le');
+      expect(decoded).toContain("it''s a test");
+    });
+
+    it('handles square brackets without spurious backticks (uses SetFileDropList)', async () => {
+      await Clipboard.copyFileReference('C:\\Users\\test[1]\\output.xml');
+
+      const [cmd] = execSync.mock.calls[0];
+      const base64 = cmd.split('-EncodedCommand ')[1];
+      const decoded = Buffer.from(base64, 'base64').toString('utf16le');
+      // SetFileDropList does not glob-expand, so brackets are passed literally
+      expect(decoded).toContain('test[1]');
+      // No backtick escaping should be present
+      expect(decoded).not.toContain('`[');
+    });
+
+    it('handles paths with dollar signs', async () => {
+      await Clipboard.copyFileReference('C:\\Users\\$data\\output.xml');
+
+      const [cmd] = execSync.mock.calls[0];
+      const base64 = cmd.split('-EncodedCommand ')[1];
+      const decoded = Buffer.from(base64, 'base64').toString('utf16le');
+      expect(decoded).toContain('$data');
+      expect(decoded).toContain('SetFileDropList');
+    });
+
+    it('handles Windows UNC paths', async () => {
+      await Clipboard.copyFileReference('\\\\server\\share\\file.xml');
+
+      const [cmd] = execSync.mock.calls[0];
+      const base64 = cmd.split('-EncodedCommand ')[1];
+      const decoded = Buffer.from(base64, 'base64').toString('utf16le');
+      expect(decoded).toContain('\\\\server\\share\\file.xml');
+    });
+
+    it('falls back to copyText on PowerShell failure', async () => {
+      execSync.mockImplementationOnce(() => {
+        throw new Error('PowerShell not found');
+      });
+      const spy = jest.spyOn(Clipboard, 'copyText').mockResolvedValueOnce();
+
+      await Clipboard.copyFileReference('C:\\test\\file.xml');
+
+      expect(spy).toHaveBeenCalledWith('C:\\test\\file.xml');
+      spy.mockRestore();
+    });
+  });
+
+  describe('copyFileReference — macOS', () => {
+    beforeEach(() => setPlatform('darwin'));
+
+    it('uses spawnSync with osascript (no shell layer)', async () => {
+      await Clipboard.copyFileReference('/Users/test/output.xml');
+
+      expect(spawnSync).toHaveBeenCalledTimes(1);
+      expect(execSync).not.toHaveBeenCalled();
+      expect(spawnSync).toHaveBeenCalledWith(
+        'osascript',
+        ['-e', expect.stringContaining('POSIX file "/Users/test/output.xml"')],
+        expect.objectContaining({ stdio: 'pipe' }),
+      );
+    });
+
+    it('escapes double quotes for AppleScript', async () => {
+      await Clipboard.copyFileReference('/Users/test/"quoted"/file.xml');
+
+      const script = spawnSync.mock.calls[0][1][1];
+      expect(script).toContain('\\"quoted\\"');
+    });
+
+    it('escapes backslashes for AppleScript', async () => {
+      await Clipboard.copyFileReference('/Users/test\\path/file.xml');
+
+      const script = spawnSync.mock.calls[0][1][1];
+      expect(script).toContain('test\\\\path');
+    });
+
+    it('safely handles paths with single quotes (no shell injection)', async () => {
+      // Previously used execSync(`osascript -e '...'`) which was vulnerable to single-quote injection.
+      // Now uses spawnSync — single quotes in the path are passed verbatim to osascript.
+      await Clipboard.copyFileReference("/Users/it's/file.xml");
+
+      expect(spawnSync).toHaveBeenCalledTimes(1);
+      expect(execSync).not.toHaveBeenCalled();
+      const script = spawnSync.mock.calls[0][1][1];
+      expect(script).toContain("it's");
+    });
+  });
+
+  describe('copyFileReference — Linux', () => {
+    beforeEach(() => setPlatform('linux'));
+
+    it('copies file:// URI to clipboard', async () => {
+      const spy = jest.spyOn(Clipboard, 'copyText').mockResolvedValueOnce();
+
+      await Clipboard.copyFileReference('/home/user/file.txt');
+
+      expect(spy).toHaveBeenCalledWith(expect.stringMatching(/^file:\/\/\/home\/user\/file\.txt$/));
+      spy.mockRestore();
+    });
+  });
+
+  describe('revealInFinder — Windows', () => {
+    beforeEach(() => setPlatform('win32'));
+
+    it('uses spawnSync instead of execSync to avoid shell injection', async () => {
+      await Clipboard.revealInFinder('C:\\Users\\test\\file.xml');
+
+      expect(spawnSync).toHaveBeenCalledTimes(1);
+      expect(execSync).not.toHaveBeenCalled();
+      expect(spawnSync).toHaveBeenCalledWith('explorer', ['/select,C:\\Users\\test\\file.xml'], {
+        stdio: 'pipe',
+      });
+    });
+
+    it('safely handles paths with shell metacharacters', async () => {
+      await Clipboard.revealInFinder('C:\\Users\\test&malicious|path\\file.xml');
+
+      expect(spawnSync).toHaveBeenCalledWith(
+        'explorer',
+        ['/select,C:\\Users\\test&malicious|path\\file.xml'],
+        { stdio: 'pipe' },
+      );
+      expect(execSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('revealInFinder — macOS', () => {
+    beforeEach(() => setPlatform('darwin'));
+
+    it('uses spawnSync with osascript (no shell layer)', async () => {
+      await Clipboard.revealInFinder('/Users/test/file.xml');
+
+      expect(spawnSync).toHaveBeenCalledTimes(1);
+      expect(execSync).not.toHaveBeenCalled();
+    });
+
+    it('escapes double quotes in AppleScript', async () => {
+      await Clipboard.revealInFinder('/Users/test/"quoted"/file.xml');
+
+      const script = spawnSync.mock.calls[0][1][1];
+      expect(script).toContain('\\"quoted\\"');
+    });
+
+    it('escapes backslashes in AppleScript', async () => {
+      await Clipboard.revealInFinder('/Users/test\\path/file.xml');
+
+      const script = spawnSync.mock.calls[0][1][1];
+      expect(script).toContain('test\\\\path');
+    });
+
+    it('no longer has the no-op replacement bug', async () => {
+      // Previously: filePath.replace(/"/g, '"') — a no-op
+      // Now: filePath.replace(/"/g, '\\"') — actually escapes
+      await Clipboard.revealInFinder('/Users/"test"/file.xml');
+
+      const script = spawnSync.mock.calls[0][1][1];
+      expect(script).toContain('\\"test\\"');
+    });
+
+    it('safely handles paths with single quotes (no shell injection)', async () => {
+      await Clipboard.revealInFinder("/Users/it's/file.xml");
+
+      expect(spawnSync).toHaveBeenCalledTimes(1);
+      expect(execSync).not.toHaveBeenCalled();
+      const script = spawnSync.mock.calls[0][1][1];
+      expect(script).toContain("it's");
+    });
+  });
+
+  describe('revealInFinder — Linux', () => {
+    beforeEach(() => setPlatform('linux'));
+
+    it('uses spawnSync to avoid shell injection', async () => {
+      await Clipboard.revealInFinder('/home/user/dir/file.txt');
+
+      expect(spawnSync).toHaveBeenCalledTimes(1);
+      expect(execSync).not.toHaveBeenCalled();
+      expect(spawnSync).toHaveBeenCalledWith('xdg-open', ['/home/user/dir'], { stdio: 'pipe' });
+    });
+
+    it('safely handles paths with $ characters (no shell expansion)', async () => {
+      await Clipboard.revealInFinder('/home/$USER/project/file.txt');
+
+      expect(spawnSync).toHaveBeenCalledWith('xdg-open', ['/home/$USER/project'], {
+        stdio: 'pipe',
+      });
+      expect(execSync).not.toHaveBeenCalled();
+    });
+
+    it('safely handles paths with double quotes', async () => {
+      await Clipboard.revealInFinder('/home/user/"weird dir"/file.txt');
+
+      expect(spawnSync).toHaveBeenCalledWith('xdg-open', ['/home/user/"weird dir"'], {
+        stdio: 'pipe',
+      });
+      expect(execSync).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes all four clipboard/file-reference bugs reported in issue #86.

Closes #86

## Changes Made

- **`src/api/copy.js`** — Fix `Clipboard.copy(output)` → `Clipboard.copyText(output)` (the method `Clipboard.copy` did not exist; this was a `TypeError` at runtime)
- **`src/utils/clipboard.js` — Windows `copyFileReference`** — Replace `Set-Clipboard -Path` (vulnerable to `[`/`]` glob expansion with no `-LiteralPath` available) with Windows Forms `SetFileDropList` via Base64-encoded `-EncodedCommand`; eliminates all shell quoting at the Node→PowerShell boundary and prevents wildcard interpretation of brackets
- **`src/utils/clipboard.js` — macOS `copyFileReference` + `revealInFinder`** — Switch from `execSync(\`osascript -e '...'\`)` to `spawnSync('osascript', ['-e', script])`; eliminates single-quote shell injection for paths like `/Users/it's/file.xml`
- **`src/utils/clipboard.js` — macOS `revealInFinder`** — Fix no-op escape `replace(/"/g, '"')` → correct `replace(/\\/g, '\\\\').replace(/"/g, '\\"')` for AppleScript double-quoted strings
- **`src/utils/clipboard.js` — Linux `revealInFinder`** — Switch from `execSync(\`xdg-open "${dir}"\`)` to `spawnSync('xdg-open', [dir])`; eliminates `$`-expansion and double-quote injection
- **`tests/setup-global-mocks.js`** — Add `mock.default = mock` to clipboardy mock so dynamic ESM `import('clipboardy')` resolves `.default` correctly in tests
- **`tests/unit/utils/clipboard.test.js`** *(new)* — 23 unit tests covering all three platform branches and edge cases: single quotes, `[`/`]`, `$`, `&`/`|`, UNC paths, backslashes, fallback behaviour
- **`tests/unit/api/copy.test.js`** — 2 new tests: `clipboard: true` success path (asserts `copyText` is called) and error suppression (asserts `clipboardError` is recorded without throwing)