### PR TITLE
feat(api): add manifest field to CopyResult for lightweight file list

### DIFF
--- a/tests/types/api.test.ts
+++ b/tests/types/api.test.ts
@@ -19,6 +19,7 @@ import {
   ScanOptions,
   FormatOptions,
   FileResult,
+  ManifestEntry,
 } from 'copytree';
 
 // ============================================================================
@@ -212,6 +213,13 @@ async function testCopyApi() {
   const totalSize: number = result.stats.totalSize;
   const outputSize: number | undefined = result.stats.outputSize;
   const outputPath: string | undefined = result.outputPath;
+
+  // Manifest type checks
+  const manifest: ManifestEntry[] = result.manifest;
+  manifest.forEach((entry: ManifestEntry) => {
+    const entryPath: string = entry.path;
+    const entrySize: number = entry.size;
+  });
 
   // Copy with all options
   const config = await ConfigManager.create();

--- a/tests/unit/api/copy.test.js
+++ b/tests/unit/api/copy.test.js
@@ -235,6 +235,77 @@ describe('copy()', () => {
     });
   });
 
+  describe('Manifest', () => {
+    it('should include a manifest array in the result', async () => {
+      const result = await copy(testDir);
+
+      expect(Array.isArray(result.manifest)).toBe(true);
+      expect(result.manifest.length).toBeGreaterThan(0);
+    });
+
+    it('should have correct shape on each manifest entry (path and size, no content)', async () => {
+      const result = await copy(testDir);
+
+      result.manifest.forEach((entry) => {
+        expect(typeof entry.path).toBe('string');
+        expect(entry.path.length).toBeGreaterThan(0);
+        expect(typeof entry.size).toBe('number');
+        expect(entry.size).toBeGreaterThanOrEqual(0);
+        expect(entry).not.toHaveProperty('content');
+        expect(entry).not.toHaveProperty('absolutePath');
+      });
+    });
+
+    it('should have manifest.length equal to stats.totalFiles', async () => {
+      const result = await copy(testDir);
+
+      expect(result.manifest.length).toBe(result.stats.totalFiles);
+    });
+
+    it('should have manifest paths that match result.files paths', async () => {
+      const result = await copy(testDir);
+
+      const manifestPaths = result.manifest.map((e) => e.path).sort();
+      const filePaths = result.files.map((f) => f.path).sort();
+      expect(manifestPaths).toEqual(filePaths);
+    });
+
+    it('should include manifest in dry run with same lightweight shape', async () => {
+      const result = await copy(testDir, { dryRun: true });
+
+      expect(Array.isArray(result.manifest)).toBe(true);
+      expect(result.manifest.length).toBeGreaterThan(0);
+      result.manifest.forEach((entry) => {
+        expect(typeof entry.path).toBe('string');
+        expect(typeof entry.size).toBe('number');
+        expect(entry).not.toHaveProperty('content');
+      });
+    });
+
+    it('should have manifest.length equal to stats.totalFiles in dry run', async () => {
+      const result = await copy(testDir, { dryRun: true });
+
+      expect(result.manifest.length).toBe(result.stats.totalFiles);
+    });
+
+    it('should reflect file filters in manifest', async () => {
+      const result = await copy(testDir, { filter: ['**/*.js'] });
+
+      result.manifest.forEach((entry) => {
+        expect(entry.path).toMatch(/\.js$/);
+      });
+    });
+
+    it('should return an empty manifest in dry run when filter matches no files', async () => {
+      // format() throws when files is empty, so use dryRun to test the zero-result path
+      const result = await copy(testDir, { filter: ['**/*.nope_no_match'], dryRun: true });
+
+      expect(Array.isArray(result.manifest)).toBe(true);
+      expect(result.manifest.length).toBe(0);
+      expect(result.manifest.length).toBe(result.stats.totalFiles);
+    });
+  });
+
   describe('Performance', () => {
     it('should complete within reasonable time', async () => {
       const start = Date.now();


### PR DESCRIPTION
## Summary

Adds a `manifest` field to `CopyResult` — a lightweight `Array<{ path, size }>` that lets programmatic API consumers (e.g. Canopy/Electron integrations) display file breakdowns without retaining full file content in memory.

Closes #90

## Changes Made

- **`types/index.d.ts`** — adds `ManifestEntry` interface and `manifest: ManifestEntry[]` to `CopyResult` with full JSDoc and usage examples
- **`src/api/copy.js`** — derives `manifest` via `files.map()` in both the dry-run and normal code paths; adds `@typedef ManifestEntry` and updates `CopyResult` JSDoc
- **`tests/unit/api/copy.test.js`** — 8 new tests covering manifest shape, parity with `result.files`, dry-run, file filtering, and zero-result edge case
- **`tests/types/api.test.ts`** — adds compile-time type assertions for `ManifestEntry`

## Design Notes

- `manifest` is always populated (required, not optional) — consistent with it being available in every code path
- Shape is `{ path: string, size: number }` — no `content`, `absolutePath`, or other heavy fields
- O(n) projection over the existing `files` array — negligible overhead
- `result.files` is unchanged (backwards compatible)