### PR TITLE
test(e2e): add golden file tests for Markdown formatter variants

### DIFF
--- a/tests/e2e/markdown-formatter.test.js
+++ b/tests/e2e/markdown-formatter.test.js
@@ -1,0 +1,354 @@
+/**
+ * E2E Tests: Markdown Formatter Variants
+ *
+ * Dedicated golden file tests for the Markdown formatter covering
+ * all supported modes and flag combinations:
+ * - Base output (no flags)
+ * - --with-line-numbers
+ * - --only-tree
+ * - --with-git-status
+ * - Combined flags
+ * - Fence language detection
+ */
+
+import path from 'path';
+import os from 'os';
+import { randomUUID } from 'crypto';
+import { execSync } from 'child_process';
+import { mkdirSync, cpSync, rmSync, appendFileSync, writeFileSync } from 'fs';
+import { runCli, normalize, getGitEnv } from './_utils.js';
+
+const PROJECT = path.resolve(process.cwd(), 'tests/fixtures/simple-project');
+
+describe('Markdown formatter variants', () => {
+  test('base markdown output (no extra flags)', async () => {
+    const { code, stdout, stderr } = await runCli([PROJECT, '--format', 'markdown', '--display']);
+
+    expect(code).toBe(0);
+    expect(stderr).toBe('');
+
+    const normalized = normalize(stdout, { projectRoot: PROJECT });
+    expect(normalized).toMatchGolden('markdown/base.md.golden');
+  }, 30000);
+
+  test('markdown with --with-line-numbers', async () => {
+    const { code, stdout, stderr } = await runCli([
+      PROJECT,
+      '--format',
+      'markdown',
+      '--with-line-numbers',
+      '--display',
+    ]);
+
+    expect(code).toBe(0);
+    expect(stderr).toBe('');
+
+    const normalized = normalize(stdout, { projectRoot: PROJECT });
+
+    // Verify line numbers appear in the Markdown-specific format (e.g. "   1: content")
+    expect(normalized).toMatch(/^\s+1:\s/m);
+    // Verify subsequent line numbers also appear
+    expect(normalized).toMatch(/^\s+2:\s/m);
+
+    expect(normalized).toMatchGolden('markdown/with-line-numbers.md.golden');
+  }, 30000);
+
+  test('markdown with --only-tree', async () => {
+    const { code, stdout, stderr } = await runCli([
+      PROJECT,
+      '--format',
+      'markdown',
+      '--only-tree',
+      '--display',
+    ]);
+
+    expect(code).toBe(0);
+    expect(stderr).toBe('');
+
+    const normalized = normalize(stdout, { projectRoot: PROJECT });
+
+    // Verify only_tree is true in front matter
+    expect(normalized).toMatch(/only_tree:\s*true/);
+    // Verify no Files section
+    expect(normalized).not.toMatch(/^## Files/m);
+    // Verify no file-begin markers
+    expect(normalized).not.toContain('copytree:file-begin');
+
+    expect(normalized).toMatchGolden('markdown/only-tree.md.golden');
+  }, 30000);
+
+  test('markdown with --with-git-status', async () => {
+    const tmpDir = path.join(os.tmpdir(), `copytree-md-git-${randomUUID()}`);
+    mkdirSync(tmpDir, { recursive: true });
+
+    try {
+      cpSync(PROJECT, tmpDir, { recursive: true });
+      const gitEnv = getGitEnv();
+
+      execSync('git init', { cwd: tmpDir, stdio: 'pipe' });
+      execSync('git config user.name copytree-bot', {
+        cwd: tmpDir,
+        stdio: 'pipe',
+      });
+      execSync('git config user.email bot@example.com', {
+        cwd: tmpDir,
+        stdio: 'pipe',
+      });
+
+      execSync('git add .', {
+        cwd: tmpDir,
+        stdio: 'pipe',
+        env: { ...process.env, ...gitEnv },
+      });
+      execSync('git commit -m "baseline"', {
+        cwd: tmpDir,
+        stdio: 'pipe',
+        env: { ...process.env, ...gitEnv },
+      });
+
+      // Modify a file and add an untracked file
+      appendFileSync(path.join(tmpDir, 'README.md'), '\nTemp change for testing.');
+      writeFileSync(path.join(tmpDir, 'UNTRACKED.tmp'), 'untracked content');
+
+      const { code, stdout, stderr } = await runCli([
+        tmpDir,
+        '--format',
+        'markdown',
+        '--with-git-status',
+        '--display',
+      ]);
+
+      expect(code).toBe(0);
+      expect(stderr).toBe('');
+
+      const normalized = normalize(stdout, { projectRoot: tmpDir });
+
+      // Verify git status is reflected in front matter
+      expect(normalized).toMatch(/include_git_status:\s*true/);
+
+      expect(normalized).toMatchGolden('markdown/with-git-status.md.golden');
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  test('markdown with --with-line-numbers --with-git-status (combined)', async () => {
+    const tmpDir = path.join(os.tmpdir(), `copytree-md-combined-${randomUUID()}`);
+    mkdirSync(tmpDir, { recursive: true });
+
+    try {
+      cpSync(PROJECT, tmpDir, { recursive: true });
+      const gitEnv = getGitEnv();
+
+      execSync('git init', { cwd: tmpDir, stdio: 'pipe' });
+      execSync('git config user.name copytree-bot', {
+        cwd: tmpDir,
+        stdio: 'pipe',
+      });
+      execSync('git config user.email bot@example.com', {
+        cwd: tmpDir,
+        stdio: 'pipe',
+      });
+
+      execSync('git add .', {
+        cwd: tmpDir,
+        stdio: 'pipe',
+        env: { ...process.env, ...gitEnv },
+      });
+      execSync('git commit -m "baseline"', {
+        cwd: tmpDir,
+        stdio: 'pipe',
+        env: { ...process.env, ...gitEnv },
+      });
+
+      appendFileSync(path.join(tmpDir, 'index.js'), '\n// modified line');
+
+      const { code, stdout, stderr } = await runCli([
+        tmpDir,
+        '--format',
+        'markdown',
+        '--with-line-numbers',
+        '--with-git-status',
+        '--display',
+      ]);
+
+      expect(code).toBe(0);
+      expect(stderr).toBe('');
+
+      const normalized = normalize(stdout, { projectRoot: tmpDir });
+
+      // Verify both flags reflected in front matter
+      expect(normalized).toMatch(/include_git_status:\s*true/);
+      expect(normalized).toMatch(/include_line_numbers:\s*true/);
+
+      expect(normalized).toMatchGolden('markdown/line-numbers-git-status.md.golden');
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  test('markdown with --only-tree --with-git-status (combined)', async () => {
+    const tmpDir = path.join(os.tmpdir(), `copytree-md-tree-git-${randomUUID()}`);
+    mkdirSync(tmpDir, { recursive: true });
+
+    try {
+      cpSync(PROJECT, tmpDir, { recursive: true });
+      const gitEnv = getGitEnv();
+
+      execSync('git init', { cwd: tmpDir, stdio: 'pipe' });
+      execSync('git config user.name copytree-bot', {
+        cwd: tmpDir,
+        stdio: 'pipe',
+      });
+      execSync('git config user.email bot@example.com', {
+        cwd: tmpDir,
+        stdio: 'pipe',
+      });
+
+      execSync('git add .', {
+        cwd: tmpDir,
+        stdio: 'pipe',
+        env: { ...process.env, ...gitEnv },
+      });
+      execSync('git commit -m "baseline"', {
+        cwd: tmpDir,
+        stdio: 'pipe',
+        env: { ...process.env, ...gitEnv },
+      });
+
+      appendFileSync(path.join(tmpDir, 'README.md'), '\nModified for git status.');
+
+      const { code, stdout, stderr } = await runCli([
+        tmpDir,
+        '--format',
+        'markdown',
+        '--only-tree',
+        '--with-git-status',
+        '--display',
+      ]);
+
+      expect(code).toBe(0);
+      expect(stderr).toBe('');
+
+      const normalized = normalize(stdout, { projectRoot: tmpDir });
+
+      // Both flags active
+      expect(normalized).toMatch(/only_tree:\s*true/);
+      expect(normalized).toMatch(/include_git_status:\s*true/);
+      // No file content sections
+      expect(normalized).not.toContain('copytree:file-begin');
+
+      expect(normalized).toMatchGolden('markdown/only-tree-git-status.md.golden');
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  test('fence language detection for various file types', async () => {
+    // Create a temp project with multiple file extensions
+    const tmpDir = path.join(os.tmpdir(), `copytree-md-lang-${randomUUID()}`);
+    mkdirSync(tmpDir, { recursive: true });
+
+    try {
+      const files = {
+        'app.js': 'const x = 1;',
+        'style.css': 'body { margin: 0; }',
+        'data.json': '{"key": "value"}',
+        'config.yml': 'key: value',
+        'script.py': 'print("hello")',
+        'main.go': 'package main',
+        'lib.rs': 'fn main() {}',
+        'run.sh': '#!/bin/bash',
+        'notes.txt': 'plain text notes',
+        'unknown.xyz': 'unknown extension content',
+      };
+
+      for (const [name, content] of Object.entries(files)) {
+        writeFileSync(path.join(tmpDir, name), content);
+      }
+
+      const { code, stdout, stderr } = await runCli([tmpDir, '--format', 'markdown', '--display']);
+
+      expect(code).toBe(0);
+      expect(stderr).toBe('');
+
+      const normalized = normalize(stdout, { projectRoot: tmpDir });
+
+      // Verify fence language tags for known extensions
+      expect(normalized).toMatch(/```js\n/);
+      expect(normalized).toMatch(/```css\n/);
+      expect(normalized).toMatch(/```json\n/);
+      expect(normalized).toMatch(/```yaml\n/);
+      expect(normalized).toMatch(/```python\n/);
+      expect(normalized).toMatch(/```go\n/);
+      expect(normalized).toMatch(/```rust\n/);
+      expect(normalized).toMatch(/```bash\n/);
+      expect(normalized).toMatch(/```text\n/);
+      // Unknown extension: no language tag (just ```)
+      expect(normalized).toMatch(/```\n(?:unknown extension content)/);
+
+      expect(normalized).toMatchGolden('markdown/language-detection.md.golden');
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  test('begin/end markers are properly placed', async () => {
+    const { code, stdout, stderr } = await runCli([PROJECT, '--format', 'markdown', '--display']);
+
+    expect(code).toBe(0);
+    expect(stderr).toBe('');
+
+    const normalized = normalize(stdout, { projectRoot: PROJECT });
+
+    // Count begin and end markers
+    const beginMarkers = normalized.match(/<!-- copytree:file-begin /g) || [];
+    const endMarkers = normalized.match(/<!-- copytree:file-end /g) || [];
+
+    // Should have exactly 3 file pairs (simple-project has 3 files)
+    expect(beginMarkers).toHaveLength(3);
+    expect(endMarkers).toHaveLength(3);
+
+    // Every begin marker has a matching end marker with the same path, in order
+    const beginPaths = [...normalized.matchAll(/<!-- copytree:file-begin path="(@[^"]+)"/g)].map(
+      (m) => m[1],
+    );
+    const endPaths = [...normalized.matchAll(/<!-- copytree:file-end path="(@[^"]+)"/g)].map(
+      (m) => m[1],
+    );
+
+    expect(beginPaths).toEqual(endPaths);
+
+    // Verify proper interleaving: each begin must come before its matching end
+    for (const filePath of beginPaths) {
+      const beginIdx = normalized.indexOf(`<!-- copytree:file-begin path="${filePath}"`);
+      const endIdx = normalized.indexOf(`<!-- copytree:file-end path="${filePath}"`);
+      expect(beginIdx).toBeGreaterThan(-1);
+      expect(endIdx).toBeGreaterThan(beginIdx);
+    }
+
+    // Verify instructions markers are paired
+    const instrBeginIdx = normalized.indexOf('<!-- copytree:instructions-begin');
+    const instrEndIdx = normalized.indexOf('<!-- copytree:instructions-end');
+    expect(instrBeginIdx).toBeGreaterThan(-1);
+    expect(instrEndIdx).toBeGreaterThan(instrBeginIdx);
+  }, 30000);
+
+  test('markdown with --show-size', async () => {
+    const { code, stdout, stderr } = await runCli([
+      PROJECT,
+      '--format',
+      'markdown',
+      '--show-size',
+      '--display',
+    ]);
+
+    expect(code).toBe(0);
+    expect(stderr).toBe('');
+
+    const normalized = normalize(stdout, { projectRoot: PROJECT });
+    // --show-size is a no-op for Markdown (tree already includes sizes);
+    // golden should match base output
+    expect(normalized).toMatchGolden('markdown/with-show-size.md.golden');
+  }, 30000);
+});

--- a/tests/fixtures/goldens/markdown/base.md.golden
+++ b/tests/fixtures/goldens/markdown/base.md.golden
@@ -1,0 +1,73 @@
+---
+format: copytree-md@1
+tool: copytree
+generated: "<TIMESTAMP>"
+base_path: "<PROJECT_ROOT>"
+profile: "default"
+file_count: 3
+total_size_bytes: 77
+char_limit_applied: false
+only_tree: false
+include_git_status: false
+include_line_numbers: false
+instructions:
+  name: "default"
+  included: true
+---
+
+# CopyTree Export — simple-project
+
+## Directory Tree
+```text
+├── src/
+│   └── test.js (40 B)
+├── index.js (22 B)
+└── README.md (15 B)
+```
+
+## Instructions
+
+<!-- copytree:instructions-begin name="default" -->
+```text
+This XML document represents the directory structure and contents of a project, which you will analyze to answer user questions. Reference files using @ followed by the relative path from the project root (e.g., @README.md, @src/app.js). The @ notation must not be enclosed in backticks. For example, always write "...in the file @app/page.tsx..." and never "...in the file `@app/page.tsx`...". You can also reference directories with @directory/path to instruct the agent to examine multiple files.
+```
+
+<!-- copytree:instructions-end name="default" -->
+
+## Files
+
+<!-- copytree:file-begin path="@index.js" size=22 modified="<TIMESTAMP>" hash="sha256:ca28d4e130339be96924c338e727c848a2e52d901837a76abb1e921da860e679" binary=false encoding="utf8" truncated=false -->
+
+### @index.js
+
+```js
+console.log('Hello');
+
+```
+
+<!-- copytree:file-end path="@index.js" -->
+
+<!-- copytree:file-begin path="@README.md" size=15 modified="<TIMESTAMP>" hash="sha256:d4ad9c87725fe5e63d14298b274307d6723233b916d065a005d96dbfe4f44f17" binary=false encoding="utf8" truncated=false -->
+
+### @README.md
+
+```markdown
+# Test Project
+
+```
+
+<!-- copytree:file-end path="@README.md" -->
+
+<!-- copytree:file-begin path="@src/test.js" size=40 modified="<TIMESTAMP>" hash="sha256:f5c226999c18c0561a682d753a38652568e934baa38aefadad63b8cd7e8e0c95" binary=false encoding="utf8" truncated=false -->
+
+### @src/test.js
+
+```js
+export function test() {
+  return 42;
+}
+
+```
+
+<!-- copytree:file-end path="@src/test.js" -->
+🖥️ 3 files [<MEMORY>] displayed to terminal

--- a/tests/fixtures/goldens/markdown/language-detection.md.golden
+++ b/tests/fixtures/goldens/markdown/language-detection.md.golden
@@ -1,0 +1,144 @@
+---
+format: copytree-md@1
+tool: copytree
+generated: "<TIMESTAMP>"
+base_path: "<PROJECT_ROOT>"
+profile: "default"
+file_count: 10
+total_size_bytes: 147
+char_limit_applied: false
+only_tree: false
+include_git_status: false
+include_line_numbers: false
+instructions:
+  name: "default"
+  included: true
+---
+
+# CopyTree Export — copytree-md-lang-<UUID>
+
+## Directory Tree
+```text
+├── app.js (12 B)
+├── config.yml (10 B)
+├── data.json (16 B)
+├── lib.rs (12 B)
+├── main.go (12 B)
+├── notes.txt (16 B)
+├── run.sh (11 B)
+├── script.py (14 B)
+├── style.css (19 B)
+└── unknown.xyz (25 B)
+```
+
+## Instructions
+
+<!-- copytree:instructions-begin name="default" -->
+```text
+This XML document represents the directory structure and contents of a project, which you will analyze to answer user questions. Reference files using @ followed by the relative path from the project root (e.g., @README.md, @src/app.js). The @ notation must not be enclosed in backticks. For example, always write "...in the file @app/page.tsx..." and never "...in the file `@app/page.tsx`...". You can also reference directories with @directory/path to instruct the agent to examine multiple files.
+```
+
+<!-- copytree:instructions-end name="default" -->
+
+## Files
+
+<!-- copytree:file-begin path="@app.js" size=12 modified="<TIMESTAMP>" hash="sha256:3f41cbb303012f33212c92326b27f6cc604fd414e20315cb10f2be7f1f6bb83c" binary=false encoding="utf8" truncated=false -->
+
+### @app.js
+
+```js
+const x = 1;
+```
+
+<!-- copytree:file-end path="@app.js" -->
+
+<!-- copytree:file-begin path="@config.yml" size=10 modified="<TIMESTAMP>" hash="sha256:b701870861d6ff0565b7078ee799ae7362323298a814d7af4d2dce6cb8d8b674" binary=false encoding="utf8" truncated=false -->
+
+### @config.yml
+
+```yaml
+key: value
+```
+
+<!-- copytree:file-end path="@config.yml" -->
+
+<!-- copytree:file-begin path="@data.json" size=16 modified="<TIMESTAMP>" hash="sha256:9724c1e20e6e3e4d7f57ed25f9d4efb006e508590d528c90da597f6a775c13e5" binary=false encoding="utf8" truncated=false -->
+
+### @data.json
+
+```json
+{"key": "value"}
+```
+
+<!-- copytree:file-end path="@data.json" -->
+
+<!-- copytree:file-begin path="@lib.rs" size=12 modified="<TIMESTAMP>" hash="sha256:ef32637cb9c3ec2e3968c9cbdf26a5e9c172be94f88af533e14bd43f892d5297" binary=false encoding="utf8" truncated=false -->
+
+### @lib.rs
+
+```rust
+fn main() {}
+```
+
+<!-- copytree:file-end path="@lib.rs" -->
+
+<!-- copytree:file-begin path="@main.go" size=12 modified="<TIMESTAMP>" hash="sha256:512843855fcc92a51c810b1b58e0731c01eac9a6a23c157bfa02aad71edffbe7" binary=false encoding="utf8" truncated=false -->
+
+### @main.go
+
+```go
+package main
+```
+
+<!-- copytree:file-end path="@main.go" -->
+
+<!-- copytree:file-begin path="@notes.txt" size=16 modified="<TIMESTAMP>" hash="sha256:a6c26c6984578a61bc921c82272d051993f396e1676ad8e0e8754adfa98ff5fd" binary=false encoding="utf8" truncated=false -->
+
+### @notes.txt
+
+```text
+plain text notes
+```
+
+<!-- copytree:file-end path="@notes.txt" -->
+
+<!-- copytree:file-begin path="@run.sh" size=11 modified="<TIMESTAMP>" hash="sha256:3667bb6922c0f881f5357826a9130fcce94a7144915ea65dfa472e65ae3b2049" binary=false encoding="utf8" truncated=false -->
+
+### @run.sh
+
+```bash
+#!/bin/bash
+```
+
+<!-- copytree:file-end path="@run.sh" -->
+
+<!-- copytree:file-begin path="@script.py" size=14 modified="<TIMESTAMP>" hash="sha256:957e13c0732e48fd5496f935894dc93a9da7dcd5eb8ffea52646fdf178cda1d1" binary=false encoding="utf8" truncated=false -->
+
+### @script.py
+
+```python
+print("hello")
+```
+
+<!-- copytree:file-end path="@script.py" -->
+
+<!-- copytree:file-begin path="@style.css" size=19 modified="<TIMESTAMP>" hash="sha256:3e67b4a9505b24600272f1ce6b6776c4ae2ebde88f76559d4a2a51f602d800c4" binary=false encoding="utf8" truncated=false -->
+
+### @style.css
+
+```css
+body { margin: 0; }
+```
+
+<!-- copytree:file-end path="@style.css" -->
+
+<!-- copytree:file-begin path="@unknown.xyz" size=25 modified="<TIMESTAMP>" hash="sha256:9944414ecf62503b75ceda10c2b85b7e5195440f5ea33740767a461cc8fb0d8f" binary=false encoding="utf8" truncated=false -->
+
+### @unknown.xyz
+
+```
+unknown extension content
+```
+
+<!-- copytree:file-end path="@unknown.xyz" -->
+🖥️ 10 files [<MEMORY>] displayed to terminal

--- a/tests/fixtures/goldens/markdown/line-numbers-git-status.md.golden
+++ b/tests/fixtures/goldens/markdown/line-numbers-git-status.md.golden
@@ -1,0 +1,74 @@
+---
+format: copytree-md@1
+tool: copytree
+generated: "<TIMESTAMP>"
+base_path: "<PROJECT_ROOT>"
+profile: "default"
+file_count: 3
+total_size_bytes: 94
+char_limit_applied: false
+only_tree: false
+include_git_status: true
+include_line_numbers: true
+instructions:
+  name: "default"
+  included: true
+---
+
+# CopyTree Export — copytree-md-combined-<UUID>
+
+## Directory Tree
+```text
+├── src/
+│   └── test.js (40 B)
+├── index.js (39 B)
+└── README.md (15 B)
+```
+
+## Instructions
+
+<!-- copytree:instructions-begin name="default" -->
+```text
+This XML document represents the directory structure and contents of a project, which you will analyze to answer user questions. Reference files using @ followed by the relative path from the project root (e.g., @README.md, @src/app.js). The @ notation must not be enclosed in backticks. For example, always write "...in the file @app/page.tsx..." and never "...in the file `@app/page.tsx`...". You can also reference directories with @directory/path to instruct the agent to examine multiple files.
+```
+
+<!-- copytree:instructions-end name="default" -->
+
+## Files
+
+<!-- copytree:file-begin path="@index.js" size=39 modified="<TIMESTAMP>" hash="sha256:743dbcff629be3ed2d9431d6873e090c0417632c75c19bd1edf3345054ac10b9" binary=false encoding="utf8" truncated=false -->
+
+### @index.js
+
+```js
+   1: console.log('Hello');
+   2:
+   3: // modified line
+```
+
+<!-- copytree:file-end path="@index.js" -->
+
+<!-- copytree:file-begin path="@README.md" size=15 modified="<TIMESTAMP>" hash="sha256:d4ad9c87725fe5e63d14298b274307d6723233b916d065a005d96dbfe4f44f17" binary=false encoding="utf8" truncated=false -->
+
+### @README.md
+
+```markdown
+   1: # Test Project
+   2:
+```
+
+<!-- copytree:file-end path="@README.md" -->
+
+<!-- copytree:file-begin path="@src/test.js" size=40 modified="<TIMESTAMP>" hash="sha256:f5c226999c18c0561a682d753a38652568e934baa38aefadad63b8cd7e8e0c95" binary=false encoding="utf8" truncated=false -->
+
+### @src/test.js
+
+```js
+   1: export function test() {
+   2:   return 42;
+   3: }
+   4:
+```
+
+<!-- copytree:file-end path="@src/test.js" -->
+🖥️ 3 files [<MEMORY>] displayed to terminal

--- a/tests/fixtures/goldens/markdown/only-tree-git-status.md.golden
+++ b/tests/fixtures/goldens/markdown/only-tree-git-status.md.golden
@@ -1,0 +1,36 @@
+---
+format: copytree-md@1
+tool: copytree
+generated: "<TIMESTAMP>"
+base_path: "<PROJECT_ROOT>"
+profile: "default"
+file_count: 3
+total_size_bytes: 102
+char_limit_applied: false
+only_tree: true
+include_git_status: true
+include_line_numbers: false
+instructions:
+  name: "default"
+  included: true
+---
+
+# CopyTree Export — copytree-md-tree-git-<UUID>
+
+## Directory Tree
+```text
+├── src/
+│   └── test.js (40 B)
+├── index.js (22 B)
+└── README.md (40 B)
+```
+
+## Instructions
+
+<!-- copytree:instructions-begin name="default" -->
+```text
+This XML document represents the directory structure and contents of a project, which you will analyze to answer user questions. Reference files using @ followed by the relative path from the project root (e.g., @README.md, @src/app.js). The @ notation must not be enclosed in backticks. For example, always write "...in the file @app/page.tsx..." and never "...in the file `@app/page.tsx`...". You can also reference directories with @directory/path to instruct the agent to examine multiple files.
+```
+
+<!-- copytree:instructions-end name="default" -->
+🖥️ 3 files [<MEMORY>] displayed to terminal

--- a/tests/fixtures/goldens/markdown/only-tree.md.golden
+++ b/tests/fixtures/goldens/markdown/only-tree.md.golden
@@ -1,0 +1,36 @@
+---
+format: copytree-md@1
+tool: copytree
+generated: "<TIMESTAMP>"
+base_path: "<PROJECT_ROOT>"
+profile: "default"
+file_count: 3
+total_size_bytes: 77
+char_limit_applied: false
+only_tree: true
+include_git_status: false
+include_line_numbers: false
+instructions:
+  name: "default"
+  included: true
+---
+
+# CopyTree Export — simple-project
+
+## Directory Tree
+```text
+├── src/
+│   └── test.js (40 B)
+├── index.js (22 B)
+└── README.md (15 B)
+```
+
+## Instructions
+
+<!-- copytree:instructions-begin name="default" -->
+```text
+This XML document represents the directory structure and contents of a project, which you will analyze to answer user questions. Reference files using @ followed by the relative path from the project root (e.g., @README.md, @src/app.js). The @ notation must not be enclosed in backticks. For example, always write "...in the file @app/page.tsx..." and never "...in the file `@app/page.tsx`...". You can also reference directories with @directory/path to instruct the agent to examine multiple files.
+```
+
+<!-- copytree:instructions-end name="default" -->
+🖥️ 3 files [<MEMORY>] displayed to terminal

--- a/tests/fixtures/goldens/markdown/with-git-status.md.golden
+++ b/tests/fixtures/goldens/markdown/with-git-status.md.golden
@@ -1,0 +1,74 @@
+---
+format: copytree-md@1
+tool: copytree
+generated: "<TIMESTAMP>"
+base_path: "<PROJECT_ROOT>"
+profile: "default"
+file_count: 3
+total_size_bytes: 102
+char_limit_applied: false
+only_tree: false
+include_git_status: true
+include_line_numbers: false
+instructions:
+  name: "default"
+  included: true
+---
+
+# CopyTree Export — copytree-md-git-<UUID>
+
+## Directory Tree
+```text
+├── src/
+│   └── test.js (40 B)
+├── index.js (22 B)
+└── README.md (40 B)
+```
+
+## Instructions
+
+<!-- copytree:instructions-begin name="default" -->
+```text
+This XML document represents the directory structure and contents of a project, which you will analyze to answer user questions. Reference files using @ followed by the relative path from the project root (e.g., @README.md, @src/app.js). The @ notation must not be enclosed in backticks. For example, always write "...in the file @app/page.tsx..." and never "...in the file `@app/page.tsx`...". You can also reference directories with @directory/path to instruct the agent to examine multiple files.
+```
+
+<!-- copytree:instructions-end name="default" -->
+
+## Files
+
+<!-- copytree:file-begin path="@index.js" size=22 modified="<TIMESTAMP>" hash="sha256:ca28d4e130339be96924c338e727c848a2e52d901837a76abb1e921da860e679" binary=false encoding="utf8" truncated=false -->
+
+### @index.js
+
+```js
+console.log('Hello');
+
+```
+
+<!-- copytree:file-end path="@index.js" -->
+
+<!-- copytree:file-begin path="@README.md" size=40 modified="<TIMESTAMP>" hash="sha256:5cc3fa04c204cc95ed917d155430f876502c1bab3ed32b3c3ebe9e08691ccda6" binary=false encoding="utf8" truncated=false -->
+
+### @README.md
+
+```markdown
+# Test Project
+
+Temp change for testing.
+```
+
+<!-- copytree:file-end path="@README.md" -->
+
+<!-- copytree:file-begin path="@src/test.js" size=40 modified="<TIMESTAMP>" hash="sha256:f5c226999c18c0561a682d753a38652568e934baa38aefadad63b8cd7e8e0c95" binary=false encoding="utf8" truncated=false -->
+
+### @src/test.js
+
+```js
+export function test() {
+  return 42;
+}
+
+```
+
+<!-- copytree:file-end path="@src/test.js" -->
+🖥️ 3 files [<MEMORY>] displayed to terminal

--- a/tests/fixtures/goldens/markdown/with-line-numbers.md.golden
+++ b/tests/fixtures/goldens/markdown/with-line-numbers.md.golden
@@ -1,0 +1,73 @@
+---
+format: copytree-md@1
+tool: copytree
+generated: "<TIMESTAMP>"
+base_path: "<PROJECT_ROOT>"
+profile: "default"
+file_count: 3
+total_size_bytes: 77
+char_limit_applied: false
+only_tree: false
+include_git_status: false
+include_line_numbers: true
+instructions:
+  name: "default"
+  included: true
+---
+
+# CopyTree Export — simple-project
+
+## Directory Tree
+```text
+├── src/
+│   └── test.js (40 B)
+├── index.js (22 B)
+└── README.md (15 B)
+```
+
+## Instructions
+
+<!-- copytree:instructions-begin name="default" -->
+```text
+This XML document represents the directory structure and contents of a project, which you will analyze to answer user questions. Reference files using @ followed by the relative path from the project root (e.g., @README.md, @src/app.js). The @ notation must not be enclosed in backticks. For example, always write "...in the file @app/page.tsx..." and never "...in the file `@app/page.tsx`...". You can also reference directories with @directory/path to instruct the agent to examine multiple files.
+```
+
+<!-- copytree:instructions-end name="default" -->
+
+## Files
+
+<!-- copytree:file-begin path="@index.js" size=22 modified="<TIMESTAMP>" hash="sha256:ca28d4e130339be96924c338e727c848a2e52d901837a76abb1e921da860e679" binary=false encoding="utf8" truncated=false -->
+
+### @index.js
+
+```js
+   1: console.log('Hello');
+   2:
+```
+
+<!-- copytree:file-end path="@index.js" -->
+
+<!-- copytree:file-begin path="@README.md" size=15 modified="<TIMESTAMP>" hash="sha256:d4ad9c87725fe5e63d14298b274307d6723233b916d065a005d96dbfe4f44f17" binary=false encoding="utf8" truncated=false -->
+
+### @README.md
+
+```markdown
+   1: # Test Project
+   2:
+```
+
+<!-- copytree:file-end path="@README.md" -->
+
+<!-- copytree:file-begin path="@src/test.js" size=40 modified="<TIMESTAMP>" hash="sha256:f5c226999c18c0561a682d753a38652568e934baa38aefadad63b8cd7e8e0c95" binary=false encoding="utf8" truncated=false -->
+
+### @src/test.js
+
+```js
+   1: export function test() {
+   2:   return 42;
+   3: }
+   4:
+```
+
+<!-- copytree:file-end path="@src/test.js" -->
+🖥️ 3 files [<MEMORY>] displayed to terminal

--- a/tests/fixtures/goldens/markdown/with-show-size.md.golden
+++ b/tests/fixtures/goldens/markdown/with-show-size.md.golden
@@ -1,0 +1,73 @@
+---
+format: copytree-md@1
+tool: copytree
+generated: "<TIMESTAMP>"
+base_path: "<PROJECT_ROOT>"
+profile: "default"
+file_count: 3
+total_size_bytes: 77
+char_limit_applied: false
+only_tree: false
+include_git_status: false
+include_line_numbers: false
+instructions:
+  name: "default"
+  included: true
+---
+
+# CopyTree Export — simple-project
+
+## Directory Tree
+```text
+├── src/
+│   └── test.js (40 B)
+├── index.js (22 B)
+└── README.md (15 B)
+```
+
+## Instructions
+
+<!-- copytree:instructions-begin name="default" -->
+```text
+This XML document represents the directory structure and contents of a project, which you will analyze to answer user questions. Reference files using @ followed by the relative path from the project root (e.g., @README.md, @src/app.js). The @ notation must not be enclosed in backticks. For example, always write "...in the file @app/page.tsx..." and never "...in the file `@app/page.tsx`...". You can also reference directories with @directory/path to instruct the agent to examine multiple files.
+```
+
+<!-- copytree:instructions-end name="default" -->
+
+## Files
+
+<!-- copytree:file-begin path="@index.js" size=22 modified="<TIMESTAMP>" hash="sha256:ca28d4e130339be96924c338e727c848a2e52d901837a76abb1e921da860e679" binary=false encoding="utf8" truncated=false -->
+
+### @index.js
+
+```js
+console.log('Hello');
+
+```
+
+<!-- copytree:file-end path="@index.js" -->
+
+<!-- copytree:file-begin path="@README.md" size=15 modified="<TIMESTAMP>" hash="sha256:d4ad9c87725fe5e63d14298b274307d6723233b916d065a005d96dbfe4f44f17" binary=false encoding="utf8" truncated=false -->
+
+### @README.md
+
+```markdown
+# Test Project
+
+```
+
+<!-- copytree:file-end path="@README.md" -->
+
+<!-- copytree:file-begin path="@src/test.js" size=40 modified="<TIMESTAMP>" hash="sha256:f5c226999c18c0561a682d753a38652568e934baa38aefadad63b8cd7e8e0c95" binary=false encoding="utf8" truncated=false -->
+
+### @src/test.js
+
+```js
+export function test() {
+  return 42;
+}
+
+```
+
+<!-- copytree:file-end path="@src/test.js" -->
+🖥️ 3 files [<MEMORY>] displayed to terminal


### PR DESCRIPTION
## Summary

Adds a dedicated E2E golden file test suite for the `MarkdownFormatter`, pinning its output contract across all supported modes and flag combinations. Tests are deterministic across platforms and catch formatting regressions automatically.

Closes #20

## Changes Made

- Add `tests/e2e/markdown-formatter.test.js` with 9 test cases:
  - Base markdown output (no extra flags)
  - `--with-line-numbers` with format-specific line number assertions
  - `--only-tree` verifying the `## Files` section is suppressed
  - `--with-git-status` with front-matter flag validation
  - Combined flags: `--with-line-numbers --with-git-status`
  - Combined flags: `--only-tree --with-git-status`
  - Fence language detection for 10 file extensions (js, css, json, yaml, python, go, rust, bash, txt, unknown)
  - Begin/end marker placement with interleaving order validation
  - `--show-size` (no-op for Markdown, explicitly asserted)
- Add 8 golden files in `tests/fixtures/goldens/markdown/` covering all variants
- Follow established E2E patterns from `output-formats.test.js` and `flags-and-combos.test.js`
- All 9 tests pass deterministically; full E2E suite (50 tests) passes without regressions