### PR TITLE
feat(cli): add convenience filter flags --ext, --max-depth, --min-size, --max-size

### DIFF
--- a/bin/copytree.js
+++ b/bin/copytree.js
@@ -93,6 +93,25 @@ program
   .option('--no-instructions', 'Disable including instructions in output')
   .option('--instructions <name>', 'Use custom instructions set (default: default)')
   .option('--no-validate', 'Disable configuration validation')
+  .option(
+    '--ext <extensions>',
+    'Filter by file extensions, comma-separated (e.g., .js,.ts,.tsx or js,ts)',
+  )
+  .option(
+    '--max-depth <n>',
+    'Maximum directory traversal depth (0 = root files only, 1 = one level deep, etc.)',
+    (val) => {
+      const n = parseInt(val, 10);
+      if (isNaN(n) || n < 0) {
+        throw new InvalidArgumentError(
+          `'${val}' is not a valid depth. Must be a non-negative integer.`,
+        );
+      }
+      return n;
+    },
+  )
+  .option('--min-size <size>', 'Exclude files smaller than this size (e.g., 1KB, 500B, 10MB)')
+  .option('--max-size <size>', 'Exclude files larger than this size (e.g., 10MB, 1GB)')
   .option('--secrets-guard', 'Enable automatic secret detection and redaction (default: enabled)')
   .option('--no-secrets-guard', 'Disable secret detection and redaction')
   .option(

--- a/src/utils/ignoreWalker.js
+++ b/src/utils/ignoreWalker.js
@@ -147,6 +147,7 @@ export async function* walkWithIgnore(root, options = {}) {
     initialLayers = [],
     config = {},
     cache = false,
+    maxDepth = undefined,
   } = options;
 
   // Extract retry configuration with defaults
@@ -162,7 +163,7 @@ export async function* walkWithIgnore(root, options = {}) {
   stats.directoriesPruned = 0;
   stats.filesExcluded = 0;
 
-  async function* walk(dir, layers) {
+  async function* walk(dir, layers, depth = 0) {
     stats.directoriesScanned++;
 
     // Load ignore rules at this level
@@ -262,8 +263,10 @@ export async function* walkWithIgnore(root, options = {}) {
           yield result;
         }
 
-        // Recurse into subdirectory
-        yield* walk(absPath, nextLayers);
+        // Recurse into subdirectory (respect maxDepth if set)
+        if (maxDepth === undefined || depth < maxDepth) {
+          yield* walk(absPath, nextLayers, depth + 1);
+        }
       } else {
         stats.filesScanned++;
 

--- a/tests/unit/pipeline/stages/FileDiscoveryStage.filters.test.js
+++ b/tests/unit/pipeline/stages/FileDiscoveryStage.filters.test.js
@@ -1,0 +1,234 @@
+// Unmock fs-extra for this test (real filesystem operations)
+jest.unmock('fs-extra');
+
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import { randomUUID } from 'crypto';
+
+let FileDiscoveryStage;
+
+beforeAll(async () => {
+  const mod = await import('../../../../src/pipeline/stages/FileDiscoveryStage.js');
+  FileDiscoveryStage = mod.default;
+});
+
+/**
+ * Helper to create a stage with sensible defaults for filter tests.
+ */
+function makeStage(overrides = {}) {
+  return new FileDiscoveryStage({
+    patterns: ['**/*'],
+    respectGitignore: false,
+    ...overrides,
+  });
+}
+
+/**
+ * Helper to run the stage and return file paths sorted alphabetically.
+ */
+async function discover(stage, basePath) {
+  const result = await stage.process({ basePath, options: {} });
+  return result.files.map((f) => f.path).sort();
+}
+
+describe('FileDiscoveryStage — convenience filter flags', () => {
+  let tempDir;
+
+  beforeEach(async () => {
+    tempDir = path.join(os.tmpdir(), `copytree-filters-${randomUUID()}`);
+    await fs.ensureDir(tempDir);
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+  });
+
+  // ─── Extension filter (--ext) ───────────────────────────────────────────────
+
+  describe('extFilter (--ext)', () => {
+    beforeEach(async () => {
+      await fs.ensureDir(path.join(tempDir, 'src'));
+      await fs.writeFile(path.join(tempDir, 'index.js'), 'js');
+      await fs.writeFile(path.join(tempDir, 'index.ts'), 'ts');
+      await fs.writeFile(path.join(tempDir, 'README.md'), 'md');
+      await fs.writeFile(path.join(tempDir, 'src', 'util.js'), 'js');
+      await fs.writeFile(path.join(tempDir, 'src', 'types.ts'), 'ts');
+    });
+
+    it('should return only files matching a single extension', async () => {
+      const stage = makeStage({ basePath: tempDir, extFilter: ['.js'] });
+      const paths = await discover(stage, tempDir);
+      expect(paths).toEqual(['index.js', 'src/util.js']);
+    });
+
+    it('should return files matching multiple extensions', async () => {
+      const stage = makeStage({ basePath: tempDir, extFilter: ['.js', '.ts'] });
+      const paths = await discover(stage, tempDir);
+      expect(paths).toEqual(['index.js', 'index.ts', 'src/types.ts', 'src/util.js']);
+    });
+
+    it('should be case-insensitive for extensions', async () => {
+      await fs.writeFile(path.join(tempDir, 'image.JS'), 'content');
+      const stage = makeStage({ basePath: tempDir, extFilter: ['.js'] });
+      const paths = await discover(stage, tempDir);
+      // Both .js and .JS files should match
+      expect(paths).toContain('index.js');
+      expect(paths).toContain('image.JS');
+      expect(paths).not.toContain('README.md');
+      expect(paths).not.toContain('index.ts');
+    });
+
+    it('should return nothing when no files match the extension', async () => {
+      const stage = makeStage({ basePath: tempDir, extFilter: ['.py'] });
+      const paths = await discover(stage, tempDir);
+      expect(paths).toHaveLength(0);
+    });
+
+    it('should work in combination with --filter patterns (AND logic)', async () => {
+      // --filter limits to src/** only; --ext limits to .ts — both must match
+      const stage = makeStage({
+        basePath: tempDir,
+        patterns: ['src/**'],
+        extFilter: ['.ts'],
+      });
+      const paths = await discover(stage, tempDir);
+      expect(paths).toEqual(['src/types.ts']);
+    });
+  });
+
+  // ─── Max depth (--max-depth) ─────────────────────────────────────────────────
+
+  describe('maxDepth (--max-depth)', () => {
+    beforeEach(async () => {
+      await fs.ensureDir(path.join(tempDir, 'a'));
+      await fs.ensureDir(path.join(tempDir, 'a', 'b'));
+      await fs.ensureDir(path.join(tempDir, 'a', 'b', 'c'));
+      await fs.writeFile(path.join(tempDir, 'root.txt'), 'root');
+      await fs.writeFile(path.join(tempDir, 'a', 'depth1.txt'), 'd1');
+      await fs.writeFile(path.join(tempDir, 'a', 'b', 'depth2.txt'), 'd2');
+      await fs.writeFile(path.join(tempDir, 'a', 'b', 'c', 'depth3.txt'), 'd3');
+    });
+
+    it('should return only root-level files at maxDepth=0', async () => {
+      const stage = makeStage({ basePath: tempDir, maxDepth: 0 });
+      const paths = await discover(stage, tempDir);
+      expect(paths).toEqual(['root.txt']);
+    });
+
+    it('should include one level deep at maxDepth=1', async () => {
+      const stage = makeStage({ basePath: tempDir, maxDepth: 1 });
+      const paths = await discover(stage, tempDir);
+      expect(paths).toEqual(['a/depth1.txt', 'root.txt']);
+    });
+
+    it('should include two levels deep at maxDepth=2', async () => {
+      const stage = makeStage({ basePath: tempDir, maxDepth: 2 });
+      const paths = await discover(stage, tempDir);
+      expect(paths).toEqual(['a/b/depth2.txt', 'a/depth1.txt', 'root.txt']);
+    });
+
+    it('should include all files when maxDepth exceeds actual depth', async () => {
+      const stage = makeStage({ basePath: tempDir, maxDepth: 100 });
+      const paths = await discover(stage, tempDir);
+      expect(paths).toEqual(['a/b/c/depth3.txt', 'a/b/depth2.txt', 'a/depth1.txt', 'root.txt']);
+    });
+
+    it('should include all files when maxDepth is not set', async () => {
+      const stage = makeStage({ basePath: tempDir });
+      const paths = await discover(stage, tempDir);
+      expect(paths).toEqual(['a/b/c/depth3.txt', 'a/b/depth2.txt', 'a/depth1.txt', 'root.txt']);
+    });
+
+    it('should return empty array at maxDepth=0 when root has no files (only subdirs)', async () => {
+      // Create a directory with ONLY subdirectories at the root level
+      const subdirOnlyDir = path.join(tempDir, 'subdir-only');
+      await fs.ensureDir(path.join(subdirOnlyDir, 'sub'));
+      await fs.writeFile(path.join(subdirOnlyDir, 'sub', 'nested.txt'), 'nested');
+      const stage = makeStage({ basePath: subdirOnlyDir, maxDepth: 0 });
+      const paths = await discover(stage, subdirOnlyDir);
+      expect(paths).toHaveLength(0);
+    });
+  });
+
+  // ─── Min/max size filters (--min-size / --max-size) ──────────────────────────
+
+  describe('size filters (--min-size / --max-size)', () => {
+    beforeEach(async () => {
+      // Create files of known sizes
+      await fs.writeFile(path.join(tempDir, 'empty.txt'), ''); // 0 bytes
+      await fs.writeFile(path.join(tempDir, 'small.txt'), 'a'.repeat(100)); // 100 bytes
+      await fs.writeFile(path.join(tempDir, 'medium.txt'), 'b'.repeat(1000)); // 1000 bytes
+      await fs.writeFile(path.join(tempDir, 'large.txt'), 'c'.repeat(10000)); // 10000 bytes
+    });
+
+    it('should exclude files smaller than minSizeBytes', async () => {
+      const stage = makeStage({ basePath: tempDir, minSizeBytes: 500 });
+      const paths = await discover(stage, tempDir);
+      expect(paths).toEqual(['large.txt', 'medium.txt']);
+    });
+
+    it('should exclude files larger than maxSizeBytes', async () => {
+      const stage = makeStage({ basePath: tempDir, maxSizeBytes: 500 });
+      const paths = await discover(stage, tempDir);
+      expect(paths).toEqual(['empty.txt', 'small.txt']);
+    });
+
+    it('should apply both min and max size filters simultaneously', async () => {
+      const stage = makeStage({ basePath: tempDir, minSizeBytes: 50, maxSizeBytes: 5000 });
+      const paths = await discover(stage, tempDir);
+      expect(paths).toEqual(['medium.txt', 'small.txt']);
+    });
+
+    it('should include files exactly at the boundary values', async () => {
+      const stage = makeStage({ basePath: tempDir, minSizeBytes: 100, maxSizeBytes: 1000 });
+      const paths = await discover(stage, tempDir);
+      expect(paths).toContain('small.txt'); // exactly 100 bytes
+      expect(paths).toContain('medium.txt'); // exactly 1000 bytes
+    });
+
+    it('should return nothing when size range excludes all files', async () => {
+      const stage = makeStage({ basePath: tempDir, minSizeBytes: 50000 });
+      const paths = await discover(stage, tempDir);
+      expect(paths).toHaveLength(0);
+    });
+
+    it('should include all files when no size filters are set', async () => {
+      const stage = makeStage({ basePath: tempDir });
+      const paths = await discover(stage, tempDir);
+      expect(paths).toHaveLength(4);
+    });
+  });
+
+  // ─── Combined filters ────────────────────────────────────────────────────────
+
+  describe('combined filters', () => {
+    beforeEach(async () => {
+      await fs.ensureDir(path.join(tempDir, 'src'));
+      await fs.ensureDir(path.join(tempDir, 'src', 'deep'));
+      await fs.writeFile(path.join(tempDir, 'root.js'), 'a'.repeat(200));
+      await fs.writeFile(path.join(tempDir, 'root.md'), 'b'.repeat(200));
+      await fs.writeFile(path.join(tempDir, 'src', 'lib.js'), 'c'.repeat(5000));
+      await fs.writeFile(path.join(tempDir, 'src', 'lib.ts'), 'd'.repeat(50));
+      await fs.writeFile(path.join(tempDir, 'src', 'deep', 'nested.js'), 'e'.repeat(300));
+    });
+
+    it('should combine ext, maxDepth, and size filters', async () => {
+      const stage = makeStage({
+        basePath: tempDir,
+        extFilter: ['.js'],
+        maxDepth: 1,
+        minSizeBytes: 100,
+        maxSizeBytes: 1000,
+      });
+      const paths = await discover(stage, tempDir);
+      // Only .js files, max 1 level deep, between 100 and 1000 bytes
+      // root.js (200B, depth 0) ✓
+      // root.md — wrong ext
+      // src/lib.js (5000B) — too large
+      // src/lib.ts — wrong ext
+      // src/deep/nested.js — depth 2, excluded
+      expect(paths).toEqual(['root.js']);
+    });
+  });
+});

--- a/tests/unit/utils/ignoreWalker.test.js
+++ b/tests/unit/utils/ignoreWalker.test.js
@@ -303,4 +303,65 @@ describe('ignoreWalker', () => {
       });
     });
   });
+
+  describe('maxDepth traversal limiting', () => {
+    it('should return only root-level files at maxDepth=0', async () => {
+      await withTempDir('depth-0', async (tempDir) => {
+        await createProject(tempDir, {
+          'root.txt': 'root',
+          'sub/depth1.txt': 'd1',
+          'sub/deep/depth2.txt': 'd2',
+        });
+        await settleFs(50);
+
+        const result = await getAllFiles(tempDir, { maxDepth: 0 });
+        const names = result.map((f) => path.basename(f.path)).sort();
+        expect(names).toEqual(['root.txt']);
+      });
+    });
+
+    it('should include one directory level at maxDepth=1', async () => {
+      await withTempDir('depth-1', async (tempDir) => {
+        await createProject(tempDir, {
+          'root.txt': 'root',
+          'sub/depth1.txt': 'd1',
+          'sub/deep/depth2.txt': 'd2',
+        });
+        await settleFs(50);
+
+        const result = await getAllFiles(tempDir, { maxDepth: 1 });
+        const names = result.map((f) => path.basename(f.path)).sort();
+        expect(names).toEqual(['depth1.txt', 'root.txt']);
+      });
+    });
+
+    it('should include two directory levels at maxDepth=2', async () => {
+      await withTempDir('depth-2', async (tempDir) => {
+        await createProject(tempDir, {
+          'root.txt': 'root',
+          'sub/depth1.txt': 'd1',
+          'sub/deep/depth2.txt': 'd2',
+          'sub/deep/deeper/depth3.txt': 'd3',
+        });
+        await settleFs(50);
+
+        const result = await getAllFiles(tempDir, { maxDepth: 2 });
+        const names = result.map((f) => path.basename(f.path)).sort();
+        expect(names).toEqual(['depth1.txt', 'depth2.txt', 'root.txt']);
+      });
+    });
+
+    it('should include all files when maxDepth is undefined', async () => {
+      await withTempDir('depth-unlimited', async (tempDir) => {
+        await createProject(tempDir, {
+          'root.txt': 'root',
+          'a/b/c/deep.txt': 'deep',
+        });
+        await settleFs(50);
+
+        const result = await getAllFiles(tempDir, { maxDepth: undefined });
+        expect(result).toHaveLength(2);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds four convenience CLI flags that make common file-filtering tasks fast and intuitive, without requiring glob patterns or profile edits.

Closes #28

## Changes Made

### New CLI flags (`bin/copytree.js`)
- `--ext <extensions>` — filter by file extensions, comma-separated (e.g. `.js,.ts,.tsx` or `js,ts`)
- `--max-depth <n>` — limit traversal depth (0 = root files only, 1 = one level deep, etc.)
- `--min-size <size>` — exclude files smaller than a human-readable threshold (e.g. `1KB`, `500B`)
- `--max-size <size>` — exclude files larger than a human-readable threshold (e.g. `10MB`, `1GB`)

### Wiring (`src/commands/copy.js`)
- Added `parseExtensions()` — normalises comma-separated extensions to lowercase with leading dots; throws `CommandError` for empty/degenerate input (e.g. `',,,`)
- Added `parseSizeOption()` — wraps existing `parseSize()` from `helpers.js` with a user-friendly `CommandError`
- `buildProfileFromCliOptions()` — converts the four new flags into `profile.options` fields
- `setupPipelineStages()` — forwards the new options to `FileDiscoveryStage`

### Filtering logic (`src/pipeline/stages/FileDiscoveryStage.js`)
- Constructor stores `extFilter`, `maxDepth`, `minSizeBytes`, `maxSizeBytes`
- `maxDepth` is passed to both walkers via `walkOptions`
- Extension and size filters are applied as post-filters in the discovery loop — AND logic with existing `--filter` patterns
- Force-included files (`--always` / `.copytreeinclude`) bypass ext/size filters by design (separate fast-glob path)

### Depth limiting (`src/utils/ignoreWalker.js`, `src/utils/parallelWalker.js`)
- `walkWithIgnore` — `walk()` now accepts a `depth` parameter (default `0`); recursion is skipped when `depth >= maxDepth`
- `walkParallel` — BFS queue entries carry `depth`; subdirectories are only enqueued when `depth < maxDepth`
- Both walkers use identical semantics; parity is verified by a cross-walker test

### Tests
- New `tests/unit/pipeline/stages/FileDiscoveryStage.filters.test.js` — 18 tests covering all four filters and their combinations
- Extended `tests/unit/utils/ignoreWalker.test.js` — 4 `maxDepth` cases (0, 1, 2, unlimited)
- Extended `tests/unit/utils/parallelWalker.test.js` — 5 `maxDepth` cases including sequential/parallel parity check

## Usage Examples

```bash
# Only JavaScript/TypeScript files
copytree --ext .js,.ts

# Limit depth to 2 levels
copytree --max-depth 2

# Files between 1KB and 100KB
copytree --min-size 1KB --max-size 100KB

# Combined: Python files, 3 levels deep, under 50KB
copytree --ext .py --max-depth 3 --max-size 50KB

# Combined with existing --filter (AND logic)
copytree --filter "src/**" --ext .ts
```